### PR TITLE
Klei1984/add support for 16bit le segments

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,8 @@
+﻿---
+BasedOnStyle: Google
+AccessModifierOffset: '-4'
+ColumnLimit: '120'
+IndentWidth: '4'
+TabWidth: '4'
+
+...

--- a/analyzer.h
+++ b/analyzer.h
@@ -145,6 +145,14 @@ struct Analyzer {
 							regions.labelTypes[startAddress] = FUNCTION;	// eases further script-based transformation
 						}
 					}
+				} else if (inst.addressMode == Insn::mode_16bit and inst.memoryAddress > 0) {
+					const ImageObject &obj = image.objectAt(addr);
+					/* assume that ds and cs equal segment base in 16 bit mode */
+					uint32_t virtual_address = obj.base_address + inst.memoryAddress;
+					Region *reg = regions.regionContaining(virtual_address);
+					if (reg and reg->type == DATA) {
+						regions.labelTypes[virtual_address] = DATA;
+					}
 				}
 			}
 		}
@@ -192,7 +200,7 @@ struct Analyzer {
 		size_t count = addSwitchAddresses(fixups, size, obj.get_data_at(address), address - obj.base_address);
 		if (count > 0) {
 			const ImageObject &obj2 = image.objectAt(address);
-			regions.splitInsert(reg, Region(address, 4 * count, SWITCH,
+			regions.splitInsert(reg, Region(address, sizeof(uint32_t) * count, SWITCH,
 					obj2.bitness == ImageObject::DEFAULT_BITNESS_32BIT ?
 							Region::DEFAULT_BITNESS_32BIT :
 							Region::DEFAULT_BITNESS_16BIT));

--- a/analyzer.h
+++ b/analyzer.h
@@ -1,5 +1,5 @@
-#ifndef SRC_ANALYZER_H_
-#define SRC_ANALYZER_H_
+#ifndef LE_DISASM_ANALYZER_H_
+#define LE_DISASM_ANALYZER_H_
 
 #include <stdint.h>
 #include <cassert>
@@ -16,263 +16,255 @@
 #include "regions.h"
 
 struct Analyzer {
-	Regions regions;
-	std::deque<uint32_t> code_trace_queue;
-	Image &image;
-	DisInfo disasm;
+    Regions regions;
+    std::deque<uint32_t> code_trace_queue;
+    Image &image;
+    DisInfo disasm;
 
-	Analyzer(LinearExecutable &lx, Image &image_) : regions(lx.objects), image(image_) {}
+    Analyzer(LinearExecutable &lx, Image &image_) : regions(image_.objects), image(image_) {}
 
-	void add_code_trace_address(uint32_t addr, Type onlyFunctionOrJump, uint32_t refAddress = 0) {
-		this->code_trace_queue.push_back(addr);
-		regions.labelTypes[addr] = onlyFunctionOrJump;
-		if (refAddress > 0) {
-			printAddress(printAddress(std::cerr, refAddress) << " schedules ", addr) << std::endl;
-		}
-	}
+    void add_code_trace_address(uint32_t addr, Type onlyFunctionOrJump, uint32_t refAddress = 0) {
+        this->code_trace_queue.push_back(addr);
+        regions.labelTypes[addr] = onlyFunctionOrJump;
+        if (refAddress > 0) {
+            printAddress(printAddress(std::cerr, refAddress) << " schedules ", addr) << std::endl;
+        }
+    }
 
-	void trace_code(void) {
-		uint32_t address;
+    void trace_code(void) {
+        uint32_t address;
 
-		while (!this->code_trace_queue.empty()) {
-			address = this->code_trace_queue.front();
-			this->code_trace_queue.pop_front();
-			this->trace_code_at_address(address);
-		}
-	}
+        while (!this->code_trace_queue.empty()) {
+            address = this->code_trace_queue.front();
+            this->code_trace_queue.pop_front();
+            this->trace_code_at_address(address);
+        }
+    }
 
-	void trace_code_at_address(uint32_t start_addr) {
-		Region *reg = regions.regionContaining(start_addr);
-		if (reg == NULL) {
-			printAddress(std::cerr, start_addr, "Warning: Tried to trace code at an unmapped address: 0x") << std::endl;
-			return;
-		}
+    void trace_code_at_address(uint32_t start_addr) {
+        Region *reg = regions.regionContaining(start_addr);
+        if (reg == NULL) {
+            printAddress(std::cerr, start_addr, "Warning: Tried to trace code at an unmapped address: 0x") << std::endl;
+            return;
+        }
 
-		const ImageObject &obj = image.objectAt(start_addr);
-		const std::vector<uint8_t> &data = obj.data;
-		if (reg->get_type() == CODE || reg->get_type() == DATA) {/* already traced */
-			if (reg->get_type() == CODE) {
-				std::map<uint32_t, Type>::iterator label = regions.labelTypes.find(start_addr);
-				if (regions.labelTypes.end() != label && label->second == FUNC_GUESS) {
-					Insn inst;
-					disasm.setMachineType(reg->get_default_bitness() == Region::DEFAULT_BITNESS_32BIT ? bfd_mach_i386_i386 : bfd_mach_i386_i8086);
-					disasm.disassemble(start_addr, &data.front() - obj.base_address + start_addr, reg->get_end_address() - start_addr, inst);
-					label->second = (strstr(inst.text, "push") == inst.text || (strstr(inst.text, "sub") == inst.text && strstr(inst.text, ",%esp") != NULL)) ? FUNCTION : JUMP;
-				}
-			}
-			return;
-		} else if (regions.labelTypes.end() == regions.labelTypes.find(start_addr)) {
-			printAddress(std::cerr, start_addr, "Warning: Tracing code without label: 0x") << std::endl;
-			// FIXME: generate label
-		}
+        const ImageObject &obj = image.objectAt(start_addr);
+        if (reg->type() == CODE || reg->type() == DATA) { /* already traced */
+            if (reg->type() == CODE) {
+                std::map<uint32_t, Type>::iterator label = regions.labelTypes.find(start_addr);
+                if (regions.labelTypes.end() != label && label->second == FUNC_GUESS) {
+                    Insn inst(std::addressof(obj));
+                    disasm.disassemble(start_addr, obj.get_data_at(start_addr), reg->end_address() - start_addr, inst);
+                    label->second = (strstr(inst.text, "push") == inst.text ||
+                                     (strstr(inst.text, "sub") == inst.text && strstr(inst.text, ",%esp") != NULL))
+                                        ? FUNCTION
+                                        : JUMP;
+                }
+            }
+            return;
+        } else if (regions.labelTypes.end() == regions.labelTypes.find(start_addr)) {
+            printAddress(std::cerr, start_addr, "Warning: Tracing code without label: 0x") << std::endl;
+            // FIXME: generate label
+        }
 
-		Type type = CODE;
-		uint32_t nopCount = 0;
-		uint32_t addr = traceRegionUntilAnyJump(reg, start_addr, &data.front() - obj.base_address, type, nopCount);
-		if (nopCount == (addr - start_addr)) {
-			type = DATA;
-		}
-		if (DATA == type) {
-			std::map<uint32_t, Type>::iterator label = regions.labelTypes.find(start_addr);
-			if (regions.labelTypes.end() != label) {
-				label->second = DATA;
-			}
-		}
-		regions.splitInsert(*reg,
-				Region(start_addr, addr - start_addr, type,
-						obj.bitness == ImageObject::DEFAULT_BITNESS_32BIT ?
-								Region::DEFAULT_BITNESS_32BIT :
-								Region::DEFAULT_BITNESS_16BIT));
-	}
+        Type type = CODE;
+        uint32_t nopCount = 0;
+        uint32_t addr = traceRegionUntilAnyJump(reg, start_addr, obj.get_data_at(0), type, nopCount);
+        if (nopCount == (addr - start_addr)) {
+            type = DATA;
+        }
+        if (DATA == type) {
+            std::map<uint32_t, Type>::iterator label = regions.labelTypes.find(start_addr);
+            if (regions.labelTypes.end() != label) {
+                label->second = DATA;
+            }
+        }
+        regions.splitInsert(*reg, Region(start_addr, addr - start_addr, type));
+    }
 
-	size_t traceRegionUntilAnyJump(Region *&tracedReg, uint32_t &startAddress, const void *offset, Type &type, uint32_t &nopCount) {
-		uint32_t addr = startAddress;
-		for (Insn inst; addr < tracedReg->get_end_address(); ) {
-			disassemble(addr, tracedReg, inst, (uint8_t*) offset + addr, type);
-			for (addr += inst.size; Insn::JUMP == inst.type || Insn::RET == inst.type;) {
-				return addr;
-			}
-			if (DATA != type) {
-				char invalids[][6] = {"(bad)", "ss", "gs"};
-				for (size_t i = 0; i < sizeof(invalids)/sizeof(invalids[0]); ++i) {
-					if (strstr(inst.text, invalids[i]) == inst.text) {
-						type = DATA;
-						break;
-					}
-				}
-				if (strstr(inst.text, "nop") == inst.text) {
-					++nopCount;
+    size_t traceRegionUntilAnyJump(Region *&tracedReg, uint32_t &startAddress, const void *offset, Type &type,
+                                   uint32_t &nopCount) {
+        uint32_t addr = startAddress;
+        for (Insn inst(tracedReg->image_object_pointer()); addr < tracedReg->end_address();) {
+            disassemble(addr, tracedReg, inst, (uint8_t *)offset + addr, type);
+            for (addr += inst.size; Insn::JUMP == inst.type || Insn::RET == inst.type;) {
+                return addr;
+            }
+            if (DATA != type) {
+                char invalids[][6] = {"(bad)", "ss", "gs"};
+                for (size_t i = 0; i < sizeof(invalids) / sizeof(invalids[0]); ++i) {
+                    if (strstr(inst.text, invalids[i]) == inst.text) {
+                        type = DATA;
+                        break;
+                    }
+                }
+                if (strstr(inst.text, "nop") == inst.text) {
+                    ++nopCount;
 
-					/* Any FPU instruction-referenced fixup has to be data.
-					 *
-					 * Note that the FS segment override instruction prefix byte may be applied to disassembled instructions.
-					 * E.g. 0x647Fxx converts to FS JG rel8, which should not be misinterpreted as an FPU instruction.
-					 */
-				} else if (DATA != type && *inst.text == 'f' && inst.memoryAddress > 0 && strncmp(inst.text, "fs ", strlen("fs ")) != 0) {
-					Region *reg = regions.regionContaining(inst.memoryAddress);
-					if (reg == NULL) {
-						continue;
-					} else if (reg->get_type() == UNKNOWN) {
-						const ImageObject &obj = image.objectAt(inst.memoryAddress);
+                    /* Any FPU instruction-referenced fixup has to be data.
+                     *
+                     * Note that the FS segment override instruction prefix byte may be applied to disassembled
+                     * instructions.
+                     * E.g. 0x647Fxx converts to FS JG rel8, which should not be misinterpreted as an FPU instruction.
+                     */
+                } else if (DATA != type && *inst.text == 'f' && inst.memoryAddress > 0 &&
+                           strncmp(inst.text, "fs ", strlen("fs ")) != 0) {
+                    Region *reg = regions.regionContaining(inst.memoryAddress);
+                    if (reg == NULL) {
+                        continue;
+                    } else if (reg->type() == UNKNOWN) {
+                        if (strstr(inst.text, "t ") != NULL) {
+                            regions.splitInsert(*reg, Region(inst.memoryAddress, 10, DATA));
+                        } else if (strstr(inst.text, "l ") != NULL) {
+                            regions.splitInsert(*reg, Region(inst.memoryAddress, 8, DATA));
+                        } else {
+                            throw Error() << "0x" << std::hex << addr - inst.size
+                                          << ": unsupported FPU operand size in " << inst.text;
+                        }
+                        if (tracedReg == reg) {
+                            tracedReg = regions.regionContaining(inst.memoryAddress + 10);
+                        }
+                    } else if (reg->type() != DATA) {
+                        printAddress(std::cerr, inst.memoryAddress, "Warning: 0x") << " marked as data" << std::endl;
+                    }
+                    regions.labelTypes[inst.memoryAddress] = DATA;
+                } else if (addr - inst.size == startAddress && strstr(inst.text, "mov    $") == inst.text) {
+                    uint32_t dataAddress = strtol(&inst.text[strlen("mov    $")], NULL, 16);
+                    if (regions.regionContaining(dataAddress) != NULL) {
+                        const ImageObject &obj = image.objectAt(dataAddress);
+                        if (strncmp("ABNORMAL TERMINATION", (const char *)(obj.get_data_at(dataAddress)),
+                                    strlen("ABNORMAL TERMINATION")) == 0) {
+                            printAddress(printAddress(std::cerr, startAddress) << ": ___abort signature found at ",
+                                         dataAddress)
+                                << std::endl;
+                            regions.labelTypes[startAddress] = FUNCTION;  // eases further script-based transformation
+                        }
+                    }
+                } else if (inst.bitness() == BITNESS_16BIT and inst.memoryAddress > 0) {
+                    /* assume that ds and cs equal segment base in 16 bit mode */
+                    uint32_t virtual_address = inst.base_address() + inst.memoryAddress;
+                    Region *reg = regions.regionContaining(virtual_address);
+                    if (reg and reg->type() == DATA) {
+                        regions.labelTypes[virtual_address] = DATA;
+                    }
+                }
+            }
+        }
+        return addr;
+    }
 
-						if (strstr(inst.text, "t ") != NULL) {
-							regions.splitInsert(*reg, Region(inst.memoryAddress, 10, DATA,
-									obj.bitness == ImageObject::DEFAULT_BITNESS_32BIT ?
-											Region::DEFAULT_BITNESS_32BIT :
-											Region::DEFAULT_BITNESS_16BIT));
-						} else if (strstr(inst.text, "l ") != NULL) {
-							regions.splitInsert(*reg, Region(inst.memoryAddress, 8, DATA,
-									obj.bitness == ImageObject::DEFAULT_BITNESS_32BIT ?
-											Region::DEFAULT_BITNESS_32BIT :
-											Region::DEFAULT_BITNESS_16BIT));
-						} else {
-							throw Error() << "0x" << std::hex << addr - inst.size << ": unsupported FPU operand size in " << inst.text;
-						}
-						if (tracedReg == reg) {
-							tracedReg = regions.regionContaining(inst.memoryAddress + 10);
-						}
-					} else if (reg->get_type() != DATA) {
-						printAddress(std::cerr, inst.memoryAddress, "Warning: 0x") << " marked as data" << std::endl;
-					}
-					regions.labelTypes[inst.memoryAddress] = DATA;
-				} else if (addr - inst.size == startAddress && strstr(inst.text, "mov    $") == inst.text) {
-					uint32_t dataAddress = strtol(&inst.text[strlen("mov    $")], NULL, 16);
-					if (regions.regionContaining(dataAddress) != NULL) {
-						const ImageObject &obj = image.objectAt(dataAddress);
-						const std::vector<uint8_t> &data = obj.data;
-						if (strncmp("ABNORMAL TERMINATION", (const char *)(&data.front() - obj.base_address + dataAddress), strlen("ABNORMAL TERMINATION")) == 0) {
-							printAddress(printAddress(std::cerr, startAddress) << ": ___abort signature found at ", dataAddress) << std::endl;
-							regions.labelTypes[startAddress] = FUNCTION;	// eases further script-based transformation
-						}
-					}
-				} else if (inst.addressMode == Insn::mode_16bit and inst.memoryAddress > 0) {
-					const ImageObject &obj = image.objectAt(addr);
-					/* assume that ds and cs equal segment base in 16 bit mode */
-					uint32_t virtual_address = obj.base_address + inst.memoryAddress;
-					Region *reg = regions.regionContaining(virtual_address);
-					if (reg and reg->type == DATA) {
-						regions.labelTypes[virtual_address] = DATA;
-					}
-				}
-			}
-		}
-		return addr;
-	}
+    void disassemble(uint32_t addr, Region *&tracedReg, Insn &inst, const void *data_ptr, Type type) {
+        uint32_t end_addr = tracedReg->end_address();
+        for (disasm.disassemble(addr, data_ptr, end_addr - addr, inst); inst.memoryAddress == 0 || DATA == type;) {
+            return;
+        }
+        if ((Insn::COND_JUMP == inst.type || Insn::JUMP == inst.type) && strstr(inst.text, "*") == NULL) {
+            add_code_trace_address(inst.memoryAddress, JUMP, addr);
+        } else if (Insn::CALL == inst.type) {
+            add_code_trace_address(inst.memoryAddress, FUNCTION, addr);
+        }
+    }
 
-	void disassemble(uint32_t addr, Region *&tracedReg, Insn &inst, const void *data_ptr, Type type) {
-		uint32_t end_addr = tracedReg->get_end_address();
+    size_t addSwitchAddresses(std::map<uint32_t /*offset*/, uint32_t /*address*/> &fixups, size_t size,
+                              const uint8_t *data_ptr, uint32_t offset) {
+        size_t count = 0;
+        for (size_t off = 0; off + 4 <= size; off += 4, ++count) {
+            uint32_t addr = read_le<uint32_t>(data_ptr + off);
+            if (addr != 0) {
+                if (fixups.find(offset + off) == fixups.end()) {
+                    break;
+                }
+                add_code_trace_address(addr, CASE);
+            }
+        }
+        return count;
+    }
 
-		disasm.setMachineType(tracedReg->get_default_bitness() == Region::DEFAULT_BITNESS_32BIT ? bfd_mach_i386_i386 : bfd_mach_i386_i8086);
-		for (disasm.disassemble(addr, data_ptr, end_addr - addr, inst); inst.memoryAddress == 0 || DATA == type; ) {
-			return;
-		}
-		if ((Insn::COND_JUMP == inst.type || Insn::JUMP == inst.type) && strstr(inst.text, "*") == NULL) {
-			add_code_trace_address(inst.memoryAddress, JUMP, addr);
-		} else if (Insn::CALL == inst.type) {
-			add_code_trace_address(inst.memoryAddress, FUNCTION, addr);
-		}
-	}
+    void traceRegionSwitches(LinearExecutable &lx, std::map<uint32_t /*offset*/, uint32_t /*address*/> &fixups,
+                             Region &reg, uint32_t address) {
+        const ImageObject &obj = image.objectAt(reg.address());
+        if (!obj.is_executable()) {
+            return;
+        }
+        size_t size = reg.end_address() - address;
+        std::set<uint32_t>::iterator iter = lx.fixup_addresses.upper_bound(address);
+        if (lx.fixup_addresses.end() != iter) {
+            size = std::min<size_t>(size, *iter - address);
+        }
+        size_t count = addSwitchAddresses(fixups, size, obj.get_data_at(address), address - obj.base_address());
+        if (count > 0) {
+            regions.splitInsert(reg, Region(address, sizeof(uint32_t) * count, SWITCH));
+            regions.labelTypes[address] = SWITCH;
+            trace_code();  // TODO: is returning not enough?
+        }
+    }
 
-	size_t addSwitchAddresses(std::map<uint32_t/*offset*/, uint32_t/*address*/> &fixups, size_t size, const uint8_t *data_ptr, uint32_t offset) {
-		size_t count = 0;
-		for (size_t off = 0; off + 4 <= size; off += 4, ++count) {
-			uint32_t addr = read_le<uint32_t>(data_ptr + off);
-			if (addr != 0) {
-				if (fixups.find(offset + off) == fixups.end()) {
-					break;
-				}
-				add_code_trace_address(addr, CASE);
-			}
-		}
-		return count;
-	}
+    void traceSwitches(LinearExecutable &lx, std::map<uint32_t /*offset*/, uint32_t /*address*/> &fixups) {
+        for (std::map<uint32_t, uint32_t>::const_iterator itr = fixups.begin(); itr != fixups.end(); ++itr) {
+            Region *reg = regions.regionContaining(itr->second);
+            if (reg == NULL) {
+                printAddress(std::cerr, itr->second, "Warning: Removing reloc pointing to unmapped memory at 0x")
+                    << std::endl;
+                lx.fixup_addresses.erase(itr->second);
+                continue;
+            } else if (reg->type() == UNKNOWN) {
+                traceRegionSwitches(lx, fixups, *reg, itr->second);
+            }
+        }
+    }
 
-	void traceRegionSwitches(LinearExecutable &lx, std::map<uint32_t/*offset*/, uint32_t/*address*/> &fixups, Region &reg, uint32_t address) {
-		const ImageObject &obj = image.objectAt(reg.get_address());
-		if (!obj.executable) {
-			return;
-		}
-		size_t size = reg.get_end_address() - address;
-		std::set<uint32_t>::iterator iter = lx.fixup_addresses.upper_bound(address);
-		if (lx.fixup_addresses.end() != iter) {
-			size = std::min<size_t>(size, *iter - address);
-		}
-		size_t count = addSwitchAddresses(fixups, size, obj.get_data_at(address), address - obj.base_address);
-		if (count > 0) {
-			const ImageObject &obj2 = image.objectAt(address);
-			regions.splitInsert(reg, Region(address, sizeof(uint32_t) * count, SWITCH,
-					obj2.bitness == ImageObject::DEFAULT_BITNESS_32BIT ?
-							Region::DEFAULT_BITNESS_32BIT :
-							Region::DEFAULT_BITNESS_16BIT));
-			regions.labelTypes[address] = SWITCH;
-			trace_code();	// TODO: is returning not enough?
-		}
-	}
+    void traceSwitches(LinearExecutable &lx) {
+        for (size_t n = 0; n < lx.objects.size(); ++n) {
+            traceSwitches(lx, lx.fixups[n]);
+        }
+    }
 
-	void traceSwitches(LinearExecutable &lx, std::map<uint32_t/*offset*/, uint32_t/*address*/> &fixups) {
-		for (std::map<uint32_t, uint32_t>::const_iterator itr = fixups.begin(); itr != fixups.end(); ++itr) {
-			Region *reg = regions.regionContaining(itr->second);
-			if (reg == NULL) {
-				printAddress(std::cerr, itr->second, "Warning: Removing reloc pointing to unmapped memory at 0x") << std::endl;
-				lx.fixup_addresses.erase(itr->second);
-				continue;
-			} else if (reg->get_type() == UNKNOWN) {
-				traceRegionSwitches(lx, fixups, *reg, itr->second);
-			}
-		}
-	}
+    void addAddress(size_t &guess_count, uint32_t address) {
+        Type &type = regions.labelTypes[address];
+        if (FUNCTION != type and JUMP != type) {
+            printAddress(std::cerr, address, "Guessing that 0x") << " is a function" << std::endl;
+            ++guess_count;
+            type = FUNC_GUESS;
+        }
+        add_code_trace_address(address, type);
+    }
 
-	void traceSwitches(LinearExecutable &lx) {
-		for (size_t n = 0; n < lx.objects.size(); ++n) {
-			traceSwitches(lx, lx.fixups[n]);
-		}
-	}
+    void addAddressesFromUnknownRegions(size_t &guess_count,
+                                        std::map<uint32_t /*offset*/, uint32_t /*address*/> &fixups) {
+        for (std::map<uint32_t, uint32_t>::const_iterator itr = fixups.begin(); itr != fixups.end(); ++itr) {
+            Region *reg = regions.regionContaining(itr->second);
+            if (reg == NULL) {
+                continue;
+            } else if (reg->type() == UNKNOWN) {
+                addAddress(guess_count, itr->second);
+            } else if (reg->type() == DATA) {
+                regions.labelTypes[itr->second] = DATA;
+            }
+        }
+    }
 
-	void addAddress(size_t &guess_count, uint32_t address) {
-		Type &type = regions.labelTypes[address];
-		if (FUNCTION != type and JUMP != type) {
-			printAddress(std::cerr, address, "Guessing that 0x") << " is a function" << std::endl;
-			++guess_count;
-			type = FUNC_GUESS;
-		}
-		add_code_trace_address(address, type);
-	}
-
-	void addAddressesFromUnknownRegions(size_t &guess_count, std::map<uint32_t/*offset*/, uint32_t/*address*/> &fixups) {
-		for (std::map<uint32_t, uint32_t>::const_iterator itr = fixups.begin(); itr != fixups.end(); ++itr) {
-			Region *reg = regions.regionContaining(itr->second);
-			if (reg == NULL) {
-				continue;
-			} else if (reg->get_type() == UNKNOWN) {
-				addAddress(guess_count, itr->second);
-			} else if (reg->get_type() == DATA) {
-				regions.labelTypes[itr->second] = DATA;
-			}
-		}
-	}
-
-	void trace_remaining_relocs(LinearExecutable &lx) {
-		size_t guess_count = 0;
-		for (size_t n = 0; n < image.objects.size(); ++n) {
-			addAddressesFromUnknownRegions(guess_count, lx.fixups[n]);
-		}
-		std::cerr << std::dec << guess_count << " guess(es) to investigate" << std::endl;
-	}
+    void trace_remaining_relocs(LinearExecutable &lx) {
+        size_t guess_count = 0;
+        for (size_t n = 0; n < image.objects.size(); ++n) {
+            addAddressesFromUnknownRegions(guess_count, lx.fixups[n]);
+        }
+        std::cerr << std::dec << guess_count << " guess(es) to investigate" << std::endl;
+    }
 
 public:
-	void run(LinearExecutable &lx) {
-		uint32_t eip = lx.entryPointAddress();
-		add_code_trace_address(eip, FUNCTION);	// TODO: name it "_start"
-		printAddress(std::cerr, eip, "Tracing code directly accessible from the entry point at 0x") << std::endl;
-		trace_code();
+    void run(LinearExecutable &lx) {
+        uint32_t eip = lx.entryPointAddress();
+        add_code_trace_address(eip, FUNCTION);  // TODO: name it "_start"
+        printAddress(std::cerr, eip, "Tracing code directly accessible from the entry point at 0x") << std::endl;
+        trace_code();
 
-		std::cerr << "Tracing text relocs for switches..." << std::endl;
-		traceSwitches(lx);
+        std::cerr << "Tracing text relocs for switches..." << std::endl;
+        traceSwitches(lx);
 
-		std::cerr << "Tracing remaining relocs for functions and data..." << std::endl;
-		trace_remaining_relocs(lx);
-		trace_code();
-	}
+        std::cerr << "Tracing remaining relocs for functions and data..." << std::endl;
+        trace_remaining_relocs(lx);
+        trace_code();
+    }
 };
 
-#endif /* SRC_ANALYZER_H_ */
+#endif /* LE_DISASM_ANALYZER_H_ */

--- a/dis_info.h
+++ b/dis_info.h
@@ -1,49 +1,42 @@
-#ifndef SRC_DIS_INFO_H_
-#define SRC_DIS_INFO_H_
+#ifndef LE_DISASM_DIS_INFO_H_
+#define LE_DISASM_DIS_INFO_H_
 
 #include <dis-asm.h>
 
-extern "C" int print_insn_i386_att (bfd_vma pc, disassemble_info *info);
+extern "C" int print_insn_i386_att(bfd_vma pc, disassemble_info *info);
 
 #include "insn.h"
 
 class DisInfo : disassemble_info {
-	static void callbackPrintAddress(bfd_vma address, disassemble_info *info) {
-		info->fprintf_func(info->stream, "0x00%lx", address);
-		((Insn *) info->stream)->memoryAddress = address;
-	}
+    static void callbackPrintAddress(bfd_vma address, disassemble_info *info) {
+        info->fprintf_func(info->stream, "0x00%lx", address);
+        ((Insn *)info->stream)->memoryAddress = address;
+    }
+
 public:
-	DisInfo(unsigned long machine = bfd_mach_i386_i386) {
-		init_disassemble_info(this, NULL, &Insn::callbackResetTypeAndText);
-		mach = machine;
-		print_address_func = callbackPrintAddress;
-	}
+    DisInfo() {
+        init_disassemble_info(this, NULL, &Insn::callbackResetTypeAndText);
+        print_address_func = callbackPrintAddress;
+    }
 
-	void disassemble(uint32_t addr, const void *data, size_t length, Insn &insn) {
-		buffer = (bfd_byte *) data;
-		buffer_length = length;
-		buffer_vma = addr;
-		stream = &insn;
+    void disassemble(uint32_t addr, const void *data, size_t length, Insn &insn) {
+        buffer = (bfd_byte *)data;
+        buffer_length = length;
+        buffer_vma = addr;
+        stream = &insn;
+        mach = insn.bitness() == BITNESS_32BIT ? bfd_mach_i386_i386 : bfd_mach_i386_i8086;
 
-		insn.reset(mach == bfd_mach_i386_i8086 ? Insn::mode_16bit : Insn::mode_32bit);
+        insn.reset();
 
-		int size = print_insn_i386_att(addr, this);
-		if (size < 0) {	// FIXME: dump arguments to error
-			throw Error() << "Failed to disassemble instruction";
-		}
-		insn.setSize(size);
-		if (size > 0) {
-			insn.setTargetAndType(addr, data);
-		}
-	}
-
-	void setMachineType(unsigned long machine) {
-		if(machine != bfd_mach_i386_i386 && machine != bfd_mach_i386_i8086) {
-			throw Error() << "Only 16-bit or 32-bit x86 machine types are supported";
-		}
-
-		mach = machine;
-	}
+        int size = print_insn_i386_att(addr, this);
+        if (size < 0) {  // FIXME: dump arguments to error
+            throw Error() << "Failed to disassemble instruction";
+        }
+        insn.setSize(size);
+        if (size > 0) {
+            insn.setTargetAndType(addr, data);
+        }
+    }
 };
 
-#endif /* SRC_DIS_INFO_H_ */
+#endif /* LE_DISASM_DIS_INFO_H_ */

--- a/dis_info.h
+++ b/dis_info.h
@@ -13,9 +13,9 @@ class DisInfo : disassemble_info {
 		((Insn *) info->stream)->memoryAddress = address;
 	}
 public:
-	DisInfo() {
+	DisInfo(unsigned long machine = bfd_mach_i386_i386) {
 		init_disassemble_info(this, NULL, &Insn::callbackResetTypeAndText);
-		mach = bfd_mach_i386_i386;
+		mach = machine;
 		print_address_func = callbackPrintAddress;
 	}
 
@@ -24,7 +24,9 @@ public:
 		buffer_length = length;
 		buffer_vma = addr;
 		stream = &insn;
-		insn.reset();
+
+		insn.reset(mach == bfd_mach_i386_i8086 ? Insn::mode_16bit : Insn::mode_32bit);
+
 		int size = print_insn_i386_att(addr, this);
 		if (size < 0) {	// FIXME: dump arguments to error
 			throw Error() << "Failed to disassemble instruction";
@@ -33,6 +35,14 @@ public:
 		if (size > 0) {
 			insn.setTargetAndType(addr, data);
 		}
+	}
+
+	void setMachineType(unsigned long machine) {
+		if(machine != bfd_mach_i386_i386 && machine != bfd_mach_i386_i8086) {
+			throw Error() << "Only 16-bit or 32-bit x86 machine types are supported";
+		}
+
+		mach = machine;
 	}
 };
 

--- a/error.h
+++ b/error.h
@@ -1,5 +1,5 @@
-#ifndef ERROR_H_
-#define ERROR_H_
+#ifndef LE_DISASM_ERROR_H_
+#define LE_DISASM_ERROR_H_
 
 #include <sstream>
 #include <stdexcept>
@@ -12,32 +12,29 @@
 //                     <<mHealth
 //                     <<" health points!";
 struct Error : public std::exception {
-	Error() {
-		print_stacktrace();
-	}
+    Error() { print_stacktrace(); }
 
-	Error(const Error &that) {
-		mWhat += that.mStream.str();
-	}
+    Error(const Error& that) { mWhat += that.mStream.str(); }
 
-	virtual ~Error() throw() {};
+    virtual ~Error() throw(){};
 
-	virtual const char *what() const throw () {
-		if (mStream.str().size()) {
-			mWhat += mStream.str();
-			mStream.str("");
-		}
-		return mWhat.c_str();
-	}
+    virtual const char* what() const throw() {
+        if (mStream.str().size()) {
+            mWhat += mStream.str();
+            mStream.str("");
+        }
+        return mWhat.c_str();
+    }
 
-	template<typename T>
-	Error& operator<<(const T& t) {
-		mStream << t;
-		return *this;
-	}
+    template <typename T>
+    Error& operator<<(const T& t) {
+        mStream << t;
+        return *this;
+    }
+
 private:
-	mutable std::stringstream mStream;
-	mutable std::string mWhat;
+    mutable std::stringstream mStream;
+    mutable std::string mWhat;
 };
 
-#endif /* ERROR_H_ */
+#endif /* LE_DISASM_ERROR_H_ */

--- a/flags_restorer.h
+++ b/flags_restorer.h
@@ -1,16 +1,14 @@
-#ifndef FLAGS_RESTORER_H_
-#define FLAGS_RESTORER_H_
+#ifndef LE_DISASM_FLAGS_RESTORER_H_
+#define LE_DISASM_FLAGS_RESTORER_H_
 
 struct FlagsRestorer {
-	FlagsRestorer(std::ios &str) : stream(str), flags(str.flags()) {}
+    FlagsRestorer(std::ios &str) : stream(str), flags(str.flags()) {}
 
-	~FlagsRestorer(void) {
-		stream.flags(flags);
-	}
+    ~FlagsRestorer(void) { stream.flags(flags); }
 
 protected:
-	std::ios &stream;
-	std::ios::fmtflags flags;
+    std::ios &stream;
+    std::ios::fmtflags flags;
 };
 
-#endif /* FLAGS_RESTORER_H_ */
+#endif /* LE_DISASM_FLAGS_RESTORER_H_ */

--- a/insn.h
+++ b/insn.h
@@ -45,6 +45,7 @@ public:
 		memoryAddress = 0;
 		textLength = 0;
 		addressMode = mode;
+		instructionAddress = 0;
 	}
 
 	void setSize(size_t size) {
@@ -55,7 +56,9 @@ public:
 		bool have_target = true;
 		uint8_t data0 = ((uint8_t *) data)[0], data1 = 0;
 
-		if (data0 == 0x2e) {
+		this->instructionAddress = addr;
+
+		if (data0 == 0x2e) {/* CS segment override prefix */
 			if (size > 1) {
 				data0 = ((uint8_t *) data)[1];
 			}
@@ -140,6 +143,7 @@ public:
 	size_t textLength;
 	/** jump/call target or memory operand */
 	uint32_t memoryAddress;
+	uint32_t instructionAddress;
 	size_t size;
 };
 

--- a/insn.h
+++ b/insn.h
@@ -1,152 +1,147 @@
-#ifndef SRC_INSN_H_
-#define SRC_INSN_H_
+#ifndef LE_DISASM_INSN_H_
+#define LE_DISASM_INSN_H_
 
 #include <stdarg.h>
 #include <string.h>
 #include <unistd.h>
 
 #include "error.h"
+#include "le/image_object.h"
 #include "little_endian.h"
 
 class Insn {
-	char string[128];
-	static int count;
+    char string[128];
+    static int count;
+    const ImageObject *const image_object_pointer_;
 
-	int lowerCasedSpaceTrimmed(int ret, char *end) {
-		for (text = &string[0]; text < &string[textLength] + ret && isspace(*text); ++text);
-//		for (; end > text && isspace(*end); --end);
-		for (char *i = text; i <= end; *i = tolower(*i), ++i);
-		*(end + 1) = 0;
-		textLength = end + 1 - text;
-		return ret;
-	}
+    int lowerCasedSpaceTrimmed(int ret, char *end) {
+        for (text = &string[0]; text < &string[textLength] + ret && isspace(*text); ++text)
+            ;
+        //		for (; end > text && isspace(*end); --end);
+        for (char *i = text; i <= end; *i = tolower(*i), ++i)
+            ;
+        *(end + 1) = 0;
+        textLength = end + 1 - text;
+        return ret;
+    }
 
 public:
-	static int callbackResetTypeAndText(void *stream, const char *fmt, ...) {
-		va_list list;
-		Insn * insn = (Insn *) stream;
-		va_start(list, fmt);
-		int ret = vsnprintf(&insn->string[insn->textLength], sizeof(insn->string) - 1 - insn->textLength, fmt, list);
-		va_end(list);
-		insn->type = MISC;
-//		if (insn->count-- > 0) {
-//			write(2, &insn->string[0], insn->textLength + ret);
-//			write(2, "\n", 1);
-//		}
-		return insn->lowerCasedSpaceTrimmed(ret, &insn->string[insn->textLength] + ret - 1);
-	}
+    Insn(const ImageObject *const image_object_pointer) : image_object_pointer_(image_object_pointer) {
+        assert(image_object_pointer_);
+    }
 
-	enum AddressMode  {
-		mode_16bit,
-		mode_32bit
-	};
+    Bitness bitness() { return image_object_pointer_->bitness(); }
 
-	void reset(AddressMode mode = mode_32bit) {
-		memoryAddress = 0;
-		textLength = 0;
-		addressMode = mode;
-		instructionAddress = 0;
-	}
+    uint32_t base_address() { return image_object_pointer_->base_address(); }
 
-	void setSize(size_t size) {
-		this->size = size;
-	}
+    static int callbackResetTypeAndText(void *stream, const char *fmt, ...) {
+        va_list list;
+        Insn *insn = (Insn *)stream;
+        va_start(list, fmt);
+        int ret = vsnprintf(&insn->string[insn->textLength], sizeof(insn->string) - 1 - insn->textLength, fmt, list);
+        va_end(list);
+        insn->type = MISC;
 
-	void setTargetAndType(uint32_t addr, const void *data) {
-		bool have_target = true;
-		uint8_t data0 = ((uint8_t *) data)[0], data1 = 0;
+        return insn->lowerCasedSpaceTrimmed(ret, &insn->string[insn->textLength] + ret - 1);
+    }
 
-		this->instructionAddress = addr;
+    void reset() {
+        memoryAddress = 0;
+        textLength = 0;
+        instructionAddress = 0;
+    }
 
-		if (data0 == 0x2e) {/* CS segment override prefix */
-			if (size > 1) {
-				data0 = ((uint8_t *) data)[1];
-			}
-			if (size > 2) {
-				data1 = ((uint8_t *) data)[2];
-			}
-		} else if (size > 1) {
-			data1 = ((uint8_t *) data)[1];
-		}
+    void setSize(size_t size) { this->size = size; }
 
-		if (data0 == 0x0f) {
-			if (data1 >= 0x80 and data1 < 0x90) {/* j.. near */
-				type = COND_JUMP;
-			}
-		} else if (data0 == 0xe8) {/* call */
-			type = CALL;
-		} else if (data0 == 0xe9) {/* jmp near */
-			type = JUMP;
-		} else if (data0 == 0x67 and data1 == 0xe3) {/* 0x67 jmp short */
-			type = JUMP;
-		} else if (data0 == 0xc2) {/* retn */
-			type = RET;
-		} else if (data0 == 0xca) {/* lretn */
-			type = RET;
-		} else if (data0 == 0xeb) {/* jmp short */
-			type = JUMP;
-		} else if (data0 >= 0x70 and data0 < 0x80) {/* j.. short */
-			type = COND_JUMP;
-		} else if (data0 >= 0xe0 and data0 <= 0xe3) {/* loop */
-			type = COND_JUMP;
-		} else if (data0 == 0xe3) {/* jmp short */
-			type = JUMP;
-		} else if (data0 == 0xcf) {/* iret */
-			type = RET;
-		} else if (data0 == 0xc3) {/* ret */
-			type = RET;
-		} else if (data0 == 0xcb) {/* lret */
-			type = RET;
-		} else if (data0 == 0xff) {/* jmp near or call near indirect*/
-			have_target = false;
-			/* whatever... */
-			type = (strstr(text, "jmp") != NULL) ? JUMP : CALL;
-		}
+    void setTargetAndType(uint32_t addr, const void *data) {
+        bool have_target = true;
+        uint8_t data0 = ((uint8_t *)data)[0], data1 = 0;
 
-		if (have_target and (type == COND_JUMP or type == JUMP or type == CALL)) {
-			uint32_t address;
+        this->instructionAddress = addr;
 
-			if(addressMode == mode_32bit) {
-				if (size < 5) {
-					address = addr + size + read_le<int8_t>((uint8_t *) data + size - sizeof(int8_t));
-				} else {
-					address = addr + size + read_le<int32_t>((uint8_t *) data + size - sizeof(int32_t));
-				}
-			}
-			else {
-				if (size < 3) {
-					address = addr + size + read_le<int8_t>((uint8_t *) data + size - sizeof(int8_t));
-				} else {
-					address = addr + size + read_le<int16_t>((uint8_t *) data + size - sizeof(int16_t));
-				}
-			}
+        if (data0 == 0x2e) { /* CS segment override prefix */
+            if (size > 1) {
+                data0 = ((uint8_t *)data)[1];
+            }
+            if (size > 2) {
+                data1 = ((uint8_t *)data)[2];
+            }
+        } else if (size > 1) {
+            data1 = ((uint8_t *)data)[1];
+        }
 
-			if (memoryAddress != 0 && address != memoryAddress) {
-				throw Error() << "0x" << std::hex << memoryAddress << " discarded for 0x" << address;
-			}
-			memoryAddress = address;
-		} else if (memoryAddress == 0) {
-			char * addrStr = strstr(text, "s:0x");
-			if (NULL != addrStr) {
-				memoryAddress = strtol(addrStr + 2, NULL, 16);
-			}
-		}
-	}
+        if (data0 == 0x0f) {
+            if (data1 >= 0x80 and data1 < 0x90) { /* j.. near */
+                type = COND_JUMP;
+            }
+        } else if (data0 == 0xe8) { /* call */
+            type = CALL;
+        } else if (data0 == 0xe9) { /* jmp near */
+            type = JUMP;
+        } else if (data0 == 0x67 and data1 == 0xe3) { /* 0x67 jmp short */
+            type = JUMP;
+        } else if (data0 == 0xc2) { /* retn */
+            type = RET;
+        } else if (data0 == 0xca) { /* lretn */
+            type = RET;
+        } else if (data0 == 0xeb) { /* jmp short */
+            type = JUMP;
+        } else if (data0 >= 0x70 and data0 < 0x80) { /* j.. short */
+            type = COND_JUMP;
+        } else if (data0 >= 0xe0 and data0 <= 0xe3) { /* loop */
+            type = COND_JUMP;
+        } else if (data0 == 0xe3) { /* jmp short */
+            type = JUMP;
+        } else if (data0 == 0xcf) { /* iret */
+            type = RET;
+        } else if (data0 == 0xc3) { /* ret */
+            type = RET;
+        } else if (data0 == 0xcb) { /* lret */
+            type = RET;
+        } else if (data0 == 0xff) { /* jmp near or call near indirect*/
+            have_target = false;
+            /* whatever... */
+            type = (strstr(text, "jmp") != NULL) ? JUMP : CALL;
+        }
 
-	enum Type {
-		MISC, COND_JUMP, JUMP, CALL, RET
-	};
+        if (have_target and (type == COND_JUMP or type == JUMP or type == CALL)) {
+            uint32_t address;
 
-	AddressMode addressMode;
-	Type type;
-	char * text;
-	size_t textLength;
-	/** jump/call target or memory operand */
-	uint32_t memoryAddress;
-	uint32_t instructionAddress;
-	size_t size;
+            if (bitness() == BITNESS_32BIT) {
+                if (size < 5) {
+                    address = addr + size + read_le<int8_t>((uint8_t *)data + size - sizeof(int8_t));
+                } else {
+                    address = addr + size + read_le<int32_t>((uint8_t *)data + size - sizeof(int32_t));
+                }
+            } else {
+                if (size < 3) {
+                    address = addr + size + read_le<int8_t>((uint8_t *)data + size - sizeof(int8_t));
+                } else {
+                    address = addr + size + read_le<int16_t>((uint8_t *)data + size - sizeof(int16_t));
+                }
+            }
+
+            if (memoryAddress != 0 && address != memoryAddress) {
+                throw Error() << "0x" << std::hex << memoryAddress << " discarded for 0x" << address;
+            }
+            memoryAddress = address;
+        } else if (memoryAddress == 0) {
+            char *addrStr = strstr(text, "s:0x");
+            if (NULL != addrStr) {
+                memoryAddress = strtol(addrStr + 2, NULL, 16);
+            }
+        }
+    }
+
+    enum Type { MISC, COND_JUMP, JUMP, CALL, RET };
+
+    Type type;
+    char *text;
+    size_t textLength;
+    /** jump/call target or memory operand */
+    uint32_t memoryAddress;
+    uint32_t instructionAddress;
+    size_t size;
 };
 
-int Insn::count = 10;
-
-#endif /* SRC_INSN_H_ */
+#endif /* LE_DISASM_INSN_H_ */

--- a/le/fixup.h
+++ b/le/fixup.h
@@ -1,86 +1,89 @@
-#ifndef FIXUP_H
-#define FIXUP_H
+#ifndef LE_DISASM_FIXUP_H_
+#define LE_DISASM_FIXUP_H_
 
 #include <istream>
 #include <vector>
 
-#include "object_header.h"
 #include "../error.h"
+#include "object_header.h"
 
 class Fixup {
     static uint8_t throwOnInvalidAddressFlags(std::istream &is) {
         uint8_t addr_flags;
         read_le(is, addr_flags);
         if ((addr_flags & 0x20) != 0) {
-        	throw Error() << "Fixup lists not supported";
-//        } else if ((addr_flags & 0xf) != 0x7) {/* 32-bit offset */
-//        	throw Error() << "Unsupported fixup type in 0x" << std::hex << (int) addr_flags;
+            throw Error() << "Fixup lists not supported";
+            //        } else if ((addr_flags & 0xf) != 0x7) {/* 32-bit offset */
+            //        	throw Error() << "Unsupported fixup type in 0x" << std::hex << (int) addr_flags;
         }
         return addr_flags;
     }
-    
+
     static uint8_t throwOnInvalidRelocFlags(std::istream &is) {
         uint8_t reloc_flags;
         read_le(is, reloc_flags);
-        if ((reloc_flags & 0x3) != 0x0) {/* internal ref */
-        	throw Error() << "Unsupported reloc type in 0x" << std::hex << (int) reloc_flags;
+        if ((reloc_flags & 0x3) != 0x0) { /* internal ref */
+            throw Error() << "Unsupported reloc type in 0x" << std::hex << (int)reloc_flags;
         }
         return reloc_flags;
     }
-    
-    static uint8_t throwOnInvalidObjectIndex(std::istream &is, std::vector<ObjectHeader> objects, uint32_t page_offset) {
+
+    static uint8_t throwOnInvalidObjectIndex(std::istream &is, std::vector<ObjectHeader> objects,
+                                             uint32_t page_offset) {
         uint8_t obj_index;
         read_le(is, obj_index);
-        if (obj_index < 1 || obj_index > objects.size ()) {
-        	throw Error() << "Page at offset 0x" << std::hex << page_offset << ": unexpected object index " << std::dec << (int) obj_index;
+        if (obj_index < 1 || obj_index > objects.size()) {
+            throw Error() << "Page at offset 0x" << std::hex << page_offset << ": unexpected object index " << std::dec
+                          << (int)obj_index;
         }
         return obj_index - 1;
     }
 
-	static int16_t readUpToSourceOffset(std::istream &is, size_t &offset, uint8_t &addr_flags, uint8_t &reloc_flags) {
-		addr_flags = throwOnInvalidAddressFlags(is);
-		++offset;
+    static int16_t readUpToSourceOffset(std::istream &is, size_t &offset, uint8_t &addr_flags, uint8_t &reloc_flags) {
+        addr_flags = throwOnInvalidAddressFlags(is);
+        ++offset;
 
-		reloc_flags = throwOnInvalidRelocFlags(is);
-		++offset;
+        reloc_flags = throwOnInvalidRelocFlags(is);
+        ++offset;
 
-		int16_t src_off;
-		read_le(is, src_off);
-		offset += sizeof(int16_t);
-		return src_off;
-	}
-
-	static uint32_t readDestOffset(std::istream &is, size_t &offset, std::vector<ObjectHeader> objects, uint32_t page_offset, uint8_t addr_flags, uint8_t reloc_flags) {
-		if ((reloc_flags & 0x40) != 0) {/* 16-bit Object Number/Module Ordinal Flag */
-			throw Error() << "16-bit object or module ordinal numbers are not supported";
-		}
-
-		uint8_t obj_index = throwOnInvalidObjectIndex(is, objects, page_offset);
-		++offset;
-
-		uint32_t dst_off_32;
-		if ((reloc_flags & 0x10) != 0) {/* 32-bit offset */
-			read_le(is, dst_off_32);
-			offset += sizeof(dst_off_32);
-		} else if ((addr_flags & 0xf) != 0x2) {/* 16-bit offset */
-			uint16_t dst_off_16;
-			read_le(is, dst_off_16);
-			dst_off_32 = dst_off_16;
-			offset += sizeof(dst_off_16);
-		} else {
-			return obj_index + 1;
-		}
-		return objects[obj_index].base_address + dst_off_32;
-	}
-public:
-    Fixup(std::istream &is, size_t &offset_, std::vector<ObjectHeader> objects, uint32_t page_offset, uint8_t addr_flags = 0, uint8_t reloc_flags = 0) :
-    	offset(page_offset + readUpToSourceOffset(is, offset_, addr_flags, reloc_flags)),
-		address(readDestOffset(is, offset_, objects, page_offset, addr_flags, reloc_flags)) {
+        int16_t src_off;
+        read_le(is, src_off);
+        offset += sizeof(int16_t);
+        return src_off;
     }
+
+    static uint32_t readDestOffset(std::istream &is, size_t &offset, std::vector<ObjectHeader> objects,
+                                   uint32_t page_offset, uint8_t addr_flags, uint8_t reloc_flags) {
+        if ((reloc_flags & 0x40) != 0) { /* 16-bit Object Number/Module Ordinal Flag */
+            throw Error() << "16-bit object or module ordinal numbers are not supported";
+        }
+
+        uint8_t obj_index = throwOnInvalidObjectIndex(is, objects, page_offset);
+        ++offset;
+
+        uint32_t dst_off_32;
+        if ((reloc_flags & 0x10) != 0) { /* 32-bit offset */
+            read_le(is, dst_off_32);
+            offset += sizeof(dst_off_32);
+        } else if ((addr_flags & 0xf) != 0x2) { /* 16-bit offset */
+            uint16_t dst_off_16;
+            read_le(is, dst_off_16);
+            dst_off_32 = dst_off_16;
+            offset += sizeof(dst_off_16);
+        } else {
+            return obj_index + 1;
+        }
+        return objects[obj_index].base_address + dst_off_32;
+    }
+
+public:
+    Fixup(std::istream &is, size_t &offset_, std::vector<ObjectHeader> objects, uint32_t page_offset,
+          uint8_t addr_flags = 0, uint8_t reloc_flags = 0)
+        : offset(page_offset + readUpToSourceOffset(is, offset_, addr_flags, reloc_flags)),
+          address(readDestOffset(is, offset_, objects, page_offset, addr_flags, reloc_flags)) {}
 
     const uint32_t offset;
     const uint32_t address;
 };
 
-#endif /* FIXUP_H */
-
+#endif /* LE_DISASM_FIXUP_H_ */

--- a/le/header.h
+++ b/le/header.h
@@ -1,57 +1,57 @@
-#ifndef HEADER_H
-#define HEADER_H
+#ifndef LE_DISASM_HEADER_H_
+#define LE_DISASM_HEADER_H_
 
 #include "../error.h"
 #include "../little_endian.h"
 
 struct Header {
     /* "LE" signature comes before the header data */
-	uint8_t byte_order; /* 02h */
-	uint8_t word_order; /* 03h */
-    uint32_t format_version; /* 04h */
-    uint16_t cpu_type; /* 08h */
-    uint16_t os_type; /* 0Ah */
-    uint32_t module_version; /* 0Ch */
-    uint32_t module_flags; /* 10h */
-    uint32_t page_count; /* 14h */
-    uint32_t eip_object_index; /* 18h */
-    uint32_t eip_offset; /* 1Ch */
-    uint32_t esp_object_index; /* 20h */
-    uint32_t esp_offset; /* 24h */
-    uint32_t page_size; /* 28h */
-    uint32_t last_page_size; /* 2Ch */
-    uint32_t fixup_section_size; /* 30h */
-    uint32_t fixup_section_check_sum; /* 34h */
-    uint32_t loader_section_size; /* 38h */
-    uint32_t loader_section_check_sum; /* 3Ch */
-    uint32_t object_table_offset; /* 40h */
-    uint32_t object_count; /* 44h */
-    uint32_t object_page_table_offset; /* 48h */
-    uint32_t object_iterated_pages_offset; /* 4Ch */
-    uint32_t resource_table_offset; /* 50h */
-    uint32_t resource_entry_count; /* 54h */
-    uint32_t resident_name_table_offset; /* 58h */
-    uint32_t entry_table_offset; /* 5Ch */
-    uint32_t module_directives_offset; /* 60h */
-    uint32_t module_directives_count; /* 64h */
-    uint32_t fixup_page_table_offset; /* 68h */
-    uint32_t fixup_record_table_offset; /* 6Ch */
-    uint32_t import_module_name_table_offset; /* 70h */
-    uint32_t import_module_name_entry_count; /* 74h */
+    uint8_t byte_order;                          /* 02h */
+    uint8_t word_order;                          /* 03h */
+    uint32_t format_version;                     /* 04h */
+    uint16_t cpu_type;                           /* 08h */
+    uint16_t os_type;                            /* 0Ah */
+    uint32_t module_version;                     /* 0Ch */
+    uint32_t module_flags;                       /* 10h */
+    uint32_t page_count;                         /* 14h */
+    uint32_t eip_object_index;                   /* 18h */
+    uint32_t eip_offset;                         /* 1Ch */
+    uint32_t esp_object_index;                   /* 20h */
+    uint32_t esp_offset;                         /* 24h */
+    uint32_t page_size;                          /* 28h */
+    uint32_t last_page_size;                     /* 2Ch */
+    uint32_t fixup_section_size;                 /* 30h */
+    uint32_t fixup_section_check_sum;            /* 34h */
+    uint32_t loader_section_size;                /* 38h */
+    uint32_t loader_section_check_sum;           /* 3Ch */
+    uint32_t object_table_offset;                /* 40h */
+    uint32_t object_count;                       /* 44h */
+    uint32_t object_page_table_offset;           /* 48h */
+    uint32_t object_iterated_pages_offset;       /* 4Ch */
+    uint32_t resource_table_offset;              /* 50h */
+    uint32_t resource_entry_count;               /* 54h */
+    uint32_t resident_name_table_offset;         /* 58h */
+    uint32_t entry_table_offset;                 /* 5Ch */
+    uint32_t module_directives_offset;           /* 60h */
+    uint32_t module_directives_count;            /* 64h */
+    uint32_t fixup_page_table_offset;            /* 68h */
+    uint32_t fixup_record_table_offset;          /* 6Ch */
+    uint32_t import_module_name_table_offset;    /* 70h */
+    uint32_t import_module_name_entry_count;     /* 74h */
     uint32_t import_procedure_name_table_offset; /* 78h */
-    uint32_t per_page_check_sum_table_offset; /* 7Ch */
-    uint32_t data_pages_offset; /* 80h */
-    uint32_t preload_pages_count; /* 84h */
-    uint32_t non_resident_name_table_offset; /* 88h */
-    uint32_t non_resident_name_entry_count; /* 8Ch */
-    uint32_t non_resident_name_table_check_sum; /* 90h */
-    uint32_t auto_data_segment_object_index; /* 94h */
-    uint32_t debug_info_offset; /* 98h */
-    uint32_t debug_info_size; /* 9Ch */
-    uint32_t instance_pages_count; /* A0h */
-    uint32_t instance_pages_demand_count; /* A4h */
-    uint32_t heap_size; /* A8h */
-    
+    uint32_t per_page_check_sum_table_offset;    /* 7Ch */
+    uint32_t data_pages_offset;                  /* 80h */
+    uint32_t preload_pages_count;                /* 84h */
+    uint32_t non_resident_name_table_offset;     /* 88h */
+    uint32_t non_resident_name_entry_count;      /* 8Ch */
+    uint32_t non_resident_name_table_check_sum;  /* 90h */
+    uint32_t auto_data_segment_object_index;     /* 94h */
+    uint32_t debug_info_offset;                  /* 98h */
+    uint32_t debug_info_size;                    /* 9Ch */
+    uint32_t instance_pages_count;               /* A0h */
+    uint32_t instance_pages_demand_count;        /* A4h */
+    uint32_t heap_size;                          /* A8h */
+
     void throwOnInvalidSignature(std::istream &is, uint32_t &header_offset) {
         char id[3] = {"??"};
         is.seekg(0);
@@ -63,31 +63,32 @@ struct Header {
             uint8_t byte;
             read_le(is, byte);
             if (byte < 0x40) {
-            	throw Error() << "Not a LE executable, at offset 0x18: expected 0x40 or more, got 0x" << std::hex << byte;
+                throw Error() << "Not a LE executable, at offset 0x18: expected 0x40 or more, got 0x" << std::hex
+                              << byte;
             }
             is.seekg(0x3c);
             read_le(is, header_offset);
             is.seekg(header_offset);
             is.read(id, 2);
             if (strcmp(id, "LE")) {
-            	throw Error() << "Invalid LE signature: " << id;
+                throw Error() << "Invalid LE signature: " << id;
             }
         }
     }
-    
+
     Header(std::istream &is, uint32_t &header_offset) {
         throwOnInvalidSignature(is, header_offset);
         read_le(is, byte_order);
         if (byte_order != 0) {
-        	throw Error() << "Only LITTLE_ENDIAN byte order supported: " << byte_order;
+            throw Error() << "Only LITTLE_ENDIAN byte order supported: " << byte_order;
         }
         read_le(is, word_order);
         if (word_order != 0) {
-        	throw Error() << "Only LITTLE_ENDIAN word order supported: " << word_order;
+            throw Error() << "Only LITTLE_ENDIAN word order supported: " << word_order;
         }
         read_le(is, format_version);
         if (format_version > 0) {
-        	throw Error() << "Unknown LE format version: " << format_version;
+            throw Error() << "Unknown LE format version: " << format_version;
         }
         read_le(is, cpu_type);
         read_le(is, os_type);
@@ -136,5 +137,4 @@ struct Header {
     }
 };
 
-#endif /* HEADER_H */
-
+#endif /* LE_DISASM_HEADER_H_ */

--- a/le/image.h
+++ b/le/image.h
@@ -1,5 +1,5 @@
-#ifndef SRC_LE_IMAGE_H_
-#define SRC_LE_IMAGE_H_
+#ifndef LE_DISASM_LE_IMAGE_H_
+#define LE_DISASM_LE_IMAGE_H_
 
 #include <map>
 
@@ -8,68 +8,70 @@
 #include "lin_ex.h"
 
 struct Image {
-	std::vector<ImageObject> objects;
+    std::vector<ImageObject> objects;
 
-	const ImageObject &objectAt(uint32_t address) const {
-		for (size_t n = 0; n < objects.size(); ++n) {
-			const ImageObject &obj = objects[n];
-			if (obj.base_address <= address and address < obj.base_address + obj.data.size()) {
-				return obj;
-			}
-		}
-		throw Error() << "BUG: address out of image range: 0x" << std::setfill('0') << std::setw(6) << std::hex << std::noshowbase << address;
-	}
+    const ImageObject &objectAt(uint32_t address) const {
+        for (size_t n = 0; n < objects.size(); ++n) {
+            const ImageObject &obj = objects[n];
+            if (obj.base_address() <= address and address < obj.base_address() + obj.size()) {
+                return obj;
+            }
+        }
+        throw Error() << "BUG: address out of image range: 0x" << std::setfill('0') << std::setw(6) << std::hex
+                      << std::noshowbase << address;
+    }
 
-	void loadObjectData(std::istream &is, LinearExecutable &lx, std::vector<uint8_t> &data, Header &hdr, ObjectHeader &ohdr) {
-		size_t data_off = 0, page_end = std::min<size_t>(ohdr.first_page_index + ohdr.page_count, hdr.page_count);
-		for (size_t page_idx = ohdr.first_page_index; page_idx < page_end; ++page_idx) {
-			size_t size = std::min<size_t>(ohdr.virtual_size - data_off, (page_idx + 1 < hdr.page_count) ? hdr.page_size : hdr.last_page_size);
-			is.seekg(lx.offsetOfPageInFile(page_idx));
-			if (!is.read((char *) &data.front() + data_off, size).good()) {
-				throw Error() << "EOF";
-			}
-			data_off += size;
-		}
-	}
+    void loadObjectData(std::istream &is, LinearExecutable &lx, std::vector<uint8_t> &data, Header &hdr,
+                        ObjectHeader &ohdr) {
+        size_t data_off = 0, page_end = std::min<size_t>(ohdr.first_page_index + ohdr.page_count, hdr.page_count);
+        for (size_t page_idx = ohdr.first_page_index; page_idx < page_end; ++page_idx) {
+            size_t size = std::min<size_t>(ohdr.virtual_size - data_off,
+                                           (page_idx + 1 < hdr.page_count) ? hdr.page_size : hdr.last_page_size);
+            is.seekg(lx.offsetOfPageInFile(page_idx));
+            if (!is.read((char *)&data.front() + data_off, size).good()) {
+                throw Error() << "EOF";
+            }
+            data_off += size;
+        }
+    }
 
-	void applyFixups(std::map<uint32_t/*offset*/, uint32_t/*address*/> &fixups, std::vector<uint8_t> &data) {
-		for (std::map<uint32_t, uint32_t>::iterator itr = fixups.begin(); itr != fixups.end(); ++itr) {
-			if (itr->first + 4 >= data.size()) {
-				throw Error() << "Fixup points outside object boundaries";
-			}
-			void *ptr = &data.front() + itr->first;
-			if (itr->second < 256) {
-				write_le<uint16_t>(ptr, itr->second);
-			} else {
-				write_le<uint32_t>(ptr, itr->second);
-			}
-		}
-	}
+    void applyFixups(std::map<uint32_t /*offset*/, uint32_t /*address*/> &fixups, std::vector<uint8_t> &data) {
+        for (std::map<uint32_t, uint32_t>::iterator itr = fixups.begin(); itr != fixups.end(); ++itr) {
+            if (itr->first + 4 >= data.size()) {
+                throw Error() << "Fixup points outside object boundaries";
+            }
+            void *ptr = &data.front() + itr->first;
+            if (itr->second < 256) {
+                write_le<uint16_t>(ptr, itr->second);
+            } else {
+                write_le<uint32_t>(ptr, itr->second);
+            }
+        }
+    }
 
-	void outputFlatMemoryDump(char const * path) {
-		std::ofstream ofs(path, std::ofstream::binary);
-		if (ofs.is_open()) {
-			for (size_t oi = 0; oi < objects.size(); ++oi) {
-				ofs.seekp(objects[oi].base_address);
-				ofs.write((const char*) &objects[oi].data.front(),
-						&objects[oi].data.back() - &objects[oi].data.front());
-			}
-			ofs.close();
-		}
-	}
+    void outputFlatMemoryDump(char const *path) {
+        std::ofstream ofs(path, std::ofstream::binary);
+        if (ofs.is_open()) {
+            for (size_t oi = 0; oi < objects.size(); ++oi) {
+                ofs.seekp(objects[oi].base_address());
+                ofs.write((const char *)objects[oi].get_data_at(objects[oi].base_address()), objects[oi].size() - 1);
+            }
+            ofs.close();
+        }
+    }
 
-	Image(std::istream &is, LinearExecutable &lx) {
-		std::vector<uint8_t> data;
-		objects.resize(lx.objects.size());
-		for (size_t oi = 0; oi < lx.objects.size(); ++oi) {
-			ObjectHeader &ohdr = lx.objects[oi];
-			data.clear();
-			data.resize(ohdr.virtual_size);
-			loadObjectData(is, lx, data, lx.header, ohdr);
-			applyFixups(lx.fixups[oi], data);
-			objects[oi].init(oi, ohdr.base_address, ohdr.isExecutable(), ohdr.isDefaultObjectBitness32Bit(), data);
-		}
-	}
+    Image(std::istream &is, LinearExecutable &lx) {
+        std::vector<uint8_t> data;
+        objects.resize(lx.objects.size());
+        for (size_t oi = 0; oi < lx.objects.size(); ++oi) {
+            ObjectHeader &ohdr = lx.objects[oi];
+            data.clear();
+            data.resize(ohdr.virtual_size);
+            loadObjectData(is, lx, data, lx.header, ohdr);
+            applyFixups(lx.fixups[oi], data);
+            objects[oi].init(oi, ohdr.base_address, ohdr.isExecutable(), ohdr.is32BitObject(), data);
+        }
+    }
 };
 
-#endif /* SRC_LE_IMAGE_H_ */
+#endif /* LE_DISASM_LE_IMAGE_H_ */

--- a/le/image.h
+++ b/le/image.h
@@ -67,7 +67,7 @@ struct Image {
 			data.resize(ohdr.virtual_size);
 			loadObjectData(is, lx, data, lx.header, ohdr);
 			applyFixups(lx.fixups[oi], data);
-			objects[oi].init(oi, ohdr.base_address, ohdr.isExecutable(), data);
+			objects[oi].init(oi, ohdr.base_address, ohdr.isExecutable(), ohdr.isDefaultObjectBitness32Bit(), data);
 		}
 	}
 };

--- a/le/image_object.h
+++ b/le/image_object.h
@@ -1,31 +1,33 @@
-#ifndef SRC_LE_IMAGE_OBJECT_H_
-#define SRC_LE_IMAGE_OBJECT_H_
+#ifndef LE_DISASM_LE_IMAGE_OBJECT_H_
+#define LE_DISASM_LE_IMAGE_OBJECT_H_
 
 #include <vector>
 
-struct ImageObject {
-	enum DefaultBitness {
-		DEFAULT_BITNESS_32BIT,
-		DEFAULT_BITNESS_16BIT
-	};
+#include "../type.h"
 
-	size_t index;
-	uint32_t base_address;	// both available in LinearExecutable.objects
-	bool executable;
-	enum DefaultBitness bitness;
-	std::vector<uint8_t> data;
+class ImageObject {
+public:
+    void init(size_t index, uint32_t base_address, bool executable, bool bitness, const std::vector<uint8_t> &data) {
+        index_ = index;
+        base_address_ = base_address;
+        executable_ = executable;
+        bitness_ = bitness ? BITNESS_32BIT : BITNESS_16BIT;
+        data_ = data;
+    }
 
-	void init(size_t index_, uint32_t base_address_, bool executable_, bool bitness_, const std::vector<uint8_t> &data_) {
-		index = index_;
-		base_address = base_address_;
-		executable = executable_;
-		bitness = bitness_ ? DEFAULT_BITNESS_32BIT : DEFAULT_BITNESS_16BIT;
-		data = data_;
-	}
+    const uint8_t *const get_data_at(uint32_t address) const { return (&data_.front() + address - base_address_); }
+    uint32_t base_address() const { return base_address_; }
+    uint32_t size() const { return data_.size(); }
+    Bitness bitness() const { return bitness_; }
+    bool is_executable() const { return executable_; }
+    size_t index() const { return index_; }
 
-	const uint8_t *get_data_at(uint32_t address) const {
-		return (&data.front () + address - base_address);
-	}
+private:
+    size_t index_;
+    uint32_t base_address_;
+    bool executable_;
+    Bitness bitness_;
+    std::vector<uint8_t> data_;
 };
 
-#endif /* SRC_LE_IMAGE_OBJECT_H_ */
+#endif /* LE_DISASM_LE_IMAGE_OBJECT_H_ */

--- a/le/image_object.h
+++ b/le/image_object.h
@@ -4,15 +4,22 @@
 #include <vector>
 
 struct ImageObject {
+	enum DefaultBitness {
+		DEFAULT_BITNESS_32BIT,
+		DEFAULT_BITNESS_16BIT
+	};
+
 	size_t index;
 	uint32_t base_address;	// both available in LinearExecutable.objects
 	bool executable;
+	enum DefaultBitness bitness;
 	std::vector<uint8_t> data;
 
-	void init(size_t index_, uint32_t base_address_, bool executable_, const std::vector<uint8_t> &data_) {
+	void init(size_t index_, uint32_t base_address_, bool executable_, bool bitness_, const std::vector<uint8_t> &data_) {
 		index = index_;
 		base_address = base_address_;
 		executable = executable_;
+		bitness = bitness_ ? DEFAULT_BITNESS_32BIT : DEFAULT_BITNESS_16BIT;
 		data = data_;
 	}
 

--- a/le/lin_ex.h
+++ b/le/lin_ex.h
@@ -1,5 +1,5 @@
-#ifndef LIN_EX_H
-#define LIN_EX_H
+#ifndef LE_DISASM_LIN_EX_H_
+#define LE_DISASM_LIN_EX_H_
 
 #include <set>
 #include <vector>
@@ -12,30 +12,29 @@ struct LinearExecutable {
     Header header;
     std::vector<ObjectHeader> objects;
     std::vector<ObjectPageHeader> object_pages;
-    std::vector<std::map<uint32_t/*offset*/, uint32_t/*address*/> > fixups;
+    std::vector<std::map<uint32_t /*offset*/, uint32_t /*address*/> > fixups;
     std::set<uint32_t> fixup_addresses;
-    
-    uint32_t entryPointAddress() {
-    	return objects[header.eip_object_index].base_address + header.eip_offset;
-    }
+
+    uint32_t entryPointAddress() { return objects[header.eip_object_index].base_address + header.eip_offset; }
 
     size_t offsetOfPageInFile(size_t index) const {
-    	if (index < 0 || object_pages.size() <= index) {
-    		return 0;
-    	}
-    	const ObjectPageHeader &hdr = object_pages[index];
-    	return (hdr.first_number + hdr.second_number - 1) * header.page_size + header.data_pages_offset;
+        if (index < 0 || object_pages.size() <= index) {
+            return 0;
+        }
+        const ObjectPageHeader &hdr = object_pages[index];
+        return (hdr.first_number + hdr.second_number - 1) * header.page_size + header.data_pages_offset;
     }
 
-    template<typename T>
-	void loadTable(std::istream &is, uint32_t count, std::vector<T> &ret) {
-		ret.resize(count);
-		for (uint32_t n = 0; n < count; ++n) {
-			ret[n].readFrom(is);
-		}
-	}
-    
-    void loadObjectFixups(std::istream &is, std::vector<uint32_t> &fixup_record_offsets, size_t table_offset, size_t oi) {
+    template <typename T>
+    void loadTable(std::istream &is, uint32_t count, std::vector<T> &ret) {
+        ret.resize(count);
+        for (uint32_t n = 0; n < count; ++n) {
+            ret[n].readFrom(is);
+        }
+    }
+
+    void loadObjectFixups(std::istream &is, std::vector<uint32_t> &fixup_record_offsets, size_t table_offset,
+                          size_t oi) {
         ObjectHeader &obj = objects[oi];
         /* print object indices starting from 1 as defined by LE format */
         std::cerr << "Loading fixups for object " << oi + 1 << std::endl;
@@ -43,9 +42,9 @@ struct LinearExecutable {
             size_t offset = table_offset + fixup_record_offsets[n];
             size_t end = table_offset + fixup_record_offsets[n + 1];
             size_t page_offset = (n - obj.first_page_index) * header.page_size;
-            for (is.seekg(offset); offset < end; ) {
-            	std::cerr << "Loading fixup 0x" << offset << " at page " << std::dec << (n + 1 - obj.first_page_index)
-            			<< "/" << obj.page_count << ", offset 0x" << std::hex << page_offset << ": ";
+            for (is.seekg(offset); offset < end;) {
+                std::cerr << "Loading fixup 0x" << offset << " at page " << std::dec << (n + 1 - obj.first_page_index)
+                          << "/" << obj.page_count << ", offset 0x" << std::hex << page_offset << ": ";
                 Fixup fixup(is, offset, objects, page_offset);
                 fixups[oi][fixup.offset] = fixup.address;
                 fixup_addresses.insert(fixup.address);
@@ -53,31 +52,31 @@ struct LinearExecutable {
             }
         }
     }
-    
+
     void loadFixupTable(std::istream &is, std::vector<uint32_t> &fixup_record_offsets, size_t table_offset) {
         fixups.resize(objects.size());
         for (size_t oi = 0; oi < objects.size(); ++oi) {
             loadObjectFixups(is, fixup_record_offsets, table_offset, oi);
         }
     }
-    
+
     LinearExecutable(std::istream &is, uint32_t header_offset = 0) : header(is, header_offset) {
         is.seekg(header_offset + header.object_table_offset);
         loadTable(is, header.object_count, objects);
-        
+
         is.seekg(header_offset + header.object_page_table_offset);
         loadTable(is, header.page_count, object_pages);
-        
+
         std::vector<uint32_t> fixup_record_offsets;
         is.seekg(header_offset + header.fixup_page_table_offset);
-        fixup_record_offsets.resize(header.page_count + 1); /* The additional +1 record indicates the end of the Fixup Record Table */
+        fixup_record_offsets.resize(header.page_count +
+                                    1); /* The additional +1 record indicates the end of the Fixup Record Table */
         for (size_t n = 0; n <= header.page_count; ++n) {
             read_le(is, fixup_record_offsets[n]);
         }
-        
+
         loadFixupTable(is, fixup_record_offsets, header_offset + header.fixup_record_table_offset);
     }
 };
 
-#endif /* LIN_EX_H */
-
+#endif /* LE_DISASM_LIN_EX_H_ */

--- a/le/object_header.h
+++ b/le/object_header.h
@@ -8,14 +8,17 @@
 struct ObjectHeader {
 
     enum {
-        READABLE = 1 << 0,
-        WRITABLE = 1 << 1,
-        EXECUTABLE = 1 << 2,
-        RESOURCE = 1 << 3,
-        DISCARDABLE = 1 << 4,
-        SHARED = 1 << 5,
-        PRELOADED = 1 << 6,
-        INVALID = 1 << 7
+        READABLE = 1 << 0, /* 0001h = Readable Object */
+        WRITABLE = 1 << 1, /* 0002h = Writable Object */
+        EXECUTABLE = 1 << 2, /* 0004h = Executable Object */
+        RESOURCE = 1 << 3, /* 0008h = Resource Object */
+        DISCARDABLE = 1 << 4, /* 0010h = Discardable Object */
+        SHARED = 1 << 5, /* 0020h = Object is Shared */
+        PRELOADED = 1 << 6, /* 0040h = Object has Preload Pages */
+        INVALID = 1 << 7, /* 0080h = Object has Invalid Pages */
+		ZERO_FILL = 1 << 8, /* 0100h = Object has Zero Filled Pages */
+		ALIAS_REQUIRED = 1 << 12, /* 1000h = 16:16 Alias Required */
+		BIG_DEFAULT = 1 << 13 /* 2000h = Big/Default Bit Setting */
     };
 
     uint32_t virtual_size; /* 00h */
@@ -37,6 +40,10 @@ struct ObjectHeader {
 
     bool isExecutable() const {
     	return (flags & EXECUTABLE) != 0;
+    }
+
+    bool isDefaultObjectBitness32Bit() const {
+    	return  (flags & BIG_DEFAULT) != 0;
     }
 };
 

--- a/le/object_header.h
+++ b/le/object_header.h
@@ -1,32 +1,31 @@
-#ifndef OBJECT_HEADER_H
-#define OBJECT_HEADER_H
+#ifndef LE_DISASM_OBJECT_HEADER_H_
+#define LE_DISASM_OBJECT_HEADER_H_
 
 #include <istream>
 
 #include "../little_endian.h"
 
 struct ObjectHeader {
-
     enum {
-        READABLE = 1 << 0, /* 0001h = Readable Object */
-        WRITABLE = 1 << 1, /* 0002h = Writable Object */
-        EXECUTABLE = 1 << 2, /* 0004h = Executable Object */
-        RESOURCE = 1 << 3, /* 0008h = Resource Object */
-        DISCARDABLE = 1 << 4, /* 0010h = Discardable Object */
-        SHARED = 1 << 5, /* 0020h = Object is Shared */
-        PRELOADED = 1 << 6, /* 0040h = Object has Preload Pages */
-        INVALID = 1 << 7, /* 0080h = Object has Invalid Pages */
-		ZERO_FILL = 1 << 8, /* 0100h = Object has Zero Filled Pages */
-		ALIAS_REQUIRED = 1 << 12, /* 1000h = 16:16 Alias Required */
-		BIG_DEFAULT = 1 << 13 /* 2000h = Big/Default Bit Setting */
+        READABLE = 1 << 0,        /* 0001h = Readable Object */
+        WRITABLE = 1 << 1,        /* 0002h = Writable Object */
+        EXECUTABLE = 1 << 2,      /* 0004h = Executable Object */
+        RESOURCE = 1 << 3,        /* 0008h = Resource Object */
+        DISCARDABLE = 1 << 4,     /* 0010h = Discardable Object */
+        SHARED = 1 << 5,          /* 0020h = Object is Shared */
+        PRELOADED = 1 << 6,       /* 0040h = Object has Preload Pages */
+        INVALID = 1 << 7,         /* 0080h = Object has Invalid Pages */
+        ZERO_FILL = 1 << 8,       /* 0100h = Object has Zero Filled Pages */
+        ALIAS_REQUIRED = 1 << 12, /* 1000h = 16:16 Alias Required */
+        BIG_DEFAULT = 1 << 13     /* 2000h = Big/Default Bit Setting */
     };
 
-    uint32_t virtual_size; /* 00h */
-    uint32_t base_address; /* 04h */
-    uint32_t flags; /* 08h */
+    uint32_t virtual_size;     /* 00h */
+    uint32_t base_address;     /* 04h */
+    uint32_t flags;            /* 08h */
     uint32_t first_page_index; /* 0Ch */
-    uint32_t page_count; /* 10h */
-    uint32_t reserved; /* 14h */
+    uint32_t page_count;       /* 10h */
+    uint32_t reserved;         /* 14h */
 
     void readFrom(std::istream &is) {
         read_le(is, virtual_size);
@@ -38,14 +37,8 @@ struct ObjectHeader {
         --first_page_index;
     }
 
-    bool isExecutable() const {
-    	return (flags & EXECUTABLE) != 0;
-    }
-
-    bool isDefaultObjectBitness32Bit() const {
-    	return  (flags & BIG_DEFAULT) != 0;
-    }
+    bool isExecutable() const { return (flags & EXECUTABLE) != 0; }
+    bool is32BitObject() const { return (flags & BIG_DEFAULT) != 0; }
 };
 
-#endif /* OBJECT_HEADER_H */
-
+#endif /* LE_DISASM_OBJECT_HEADER_H_ */

--- a/le/object_page_header.h
+++ b/le/object_page_header.h
@@ -1,28 +1,25 @@
-#ifndef SRC_LE_OBJECT_PAGE_HEADER_H_
-#define SRC_LE_OBJECT_PAGE_HEADER_H_
+#ifndef LE_DISASM_LE_OBJECT_PAGE_HEADER_H_
+#define LE_DISASM_LE_OBJECT_PAGE_HEADER_H_
 
 #include "../error.h"
 #include "../little_endian.h"
 
 struct ObjectPageHeader {
+    enum ObjectPageType { LEGAL = 0, ITERATED = 1, INVALID = 2, ZERO_FILLED = 3, LAST = 4 };
 
-	enum ObjectPageType {
-		LEGAL = 0, ITERATED = 1, INVALID = 2, ZERO_FILLED = 3, LAST = 4
-	};
+    uint16_t first_number; /* 00h */
+    uint8_t second_number; /* 02h */
+    ObjectPageType type;   /* 03h */
 
-	uint16_t first_number; /* 00h */
-	uint8_t second_number; /* 02h */
-	ObjectPageType type; /* 03h */
-
-	void readFrom(std::istream &is) {
-		read_le(is, first_number);
-		read_le(is, second_number);
-		uint8_t byte;
-		for (read_le(is, byte); byte > 4;) {
-			throw Error() << "Invalid object page type: " << byte;
-		}
-		type = (ObjectPageType) byte;
-	}
+    void readFrom(std::istream &is) {
+        read_le(is, first_number);
+        read_le(is, second_number);
+        uint8_t byte;
+        for (read_le(is, byte); byte > 4;) {
+            throw Error() << "Invalid object page type: " << byte;
+        }
+        type = (ObjectPageType)byte;
+    }
 };
 
-#endif /* SRC_LE_OBJECT_PAGE_HEADER_H_ */
+#endif /* LE_DISASM_LE_OBJECT_PAGE_HEADER_H_ */

--- a/little_endian.h
+++ b/little_endian.h
@@ -1,47 +1,47 @@
-#ifndef SRC_LITTLE_ENDIAN_H_
-#define SRC_LITTLE_ENDIAN_H_
+#ifndef LE_DISASM_LITTLE_ENDIAN_H_
+#define LE_DISASM_LITTLE_ENDIAN_H_
 
 #include <istream>
 
 #include "error.h"
 
-template<typename T, size_t Bytes>
+template <typename T, size_t Bytes>
 static void read_le(const void *memory, T &value) {
-	value = T(0);
-	uint8_t *p = (uint8_t *) memory;
-	for (size_t n = 0; n < Bytes; ++n) {
-		value |= (T) p[n] << (n * 8);
-	}
+    value = T(0);
+    uint8_t *p = (uint8_t *)memory;
+    for (size_t n = 0; n < Bytes; ++n) {
+        value |= (T)p[n] << (n * 8);
+    }
 }
 
-template<typename T>
+template <typename T>
 void read_le(std::istream &is, T &ret) {
-	char buffer[sizeof(T)];
-	for (is.read(buffer, sizeof(T)); !is.good(); ) {
-		throw Error() << "EOF";
-	}
-	read_le<T, sizeof(T)>(buffer, ret);
+    char buffer[sizeof(T)];
+    for (is.read(buffer, sizeof(T)); !is.good();) {
+        throw Error() << "EOF";
+    }
+    read_le<T, sizeof(T)>(buffer, ret);
 }
 
-template<typename T>
+template <typename T>
 T read_le(const void *memory) {
-	T ret;
-	read_le<T, sizeof(T)>(memory, ret);
-	return ret;
+    T ret;
+    read_le<T, sizeof(T)>(memory, ret);
+    return ret;
 }
 
-template<typename T, size_t Bytes>
+template <typename T, size_t Bytes>
 static void write_le(const void *memory, T value) {
-	uint8_t *p = (uint8_t *) memory;
-	for (size_t n = 0; n < Bytes; ++n) {
-		p[n] = value & 0xff;
-		value >>= 8;
-	}
+    uint8_t *p = (uint8_t *)memory;
+    for (size_t n = 0; n < Bytes; ++n) {
+        p[n] = value & 0xff;
+        value >>= 8;
+    }
 }
 
-template<typename T>
+template <typename T>
 void write_le(const void *memory, T value) {
-	write_le<T, sizeof(T)>(memory, value);
+    write_le<T, sizeof(T)>(memory, value);
 }
 
-#endif /* SRC_LITTLE_ENDIAN_H_ */
+#endif /* LE_DISASM_LITTLE_ENDIAN_H_ */

--- a/main.cpp
+++ b/main.cpp
@@ -1,35 +1,35 @@
-#include <fstream>
 #include <cstring>
+#include <fstream>
 #define PACKAGE
 
 #include "print.h"
 
 int main(int argc, char **argv) {
-	if (argc < 2) {
-		std::cerr << "Usage: " << argv[0] << " [main.exe]\n";
-		std::cerr << "To dump flat linear executable image to a bin file: " << argv[0] << " [main.exe] [dump.bin]\n";
-		return 1;
-	}
-	try {
-		std::ifstream is(argv[1]);
-		if(!is.is_open()) {
-			std::cerr << "Error opening file: " << argv[1];
-			return 1;
-		}
+    if (argc < 2) {
+        std::cerr << "Usage: " << argv[0] << " [main.exe]\n";
+        std::cerr << "To dump flat linear executable image to a bin file: " << argv[0] << " [main.exe] [dump.bin]\n";
+        return 1;
+    }
+    try {
+        std::ifstream is(argv[1]);
+        if (!is.is_open()) {
+            std::cerr << "Error opening file: " << argv[1];
+            return 1;
+        }
 
-		LinearExecutable lx(is);
-		Image image(is, lx);
+        LinearExecutable lx(is);
+        Image image(is, lx);
 
-		if(argc >= 3) {
-			std::cerr << "Dump flat linear executable image to " << argv[2] << "\n";
-			image.outputFlatMemoryDump(argv[2]);
-		}
+        if (argc >= 3) {
+            std::cerr << "Dump flat linear executable image to " << argv[2] << "\n";
+            image.outputFlatMemoryDump(argv[2]);
+        }
 
-		Analyzer analyzer(lx, image);
+        Analyzer analyzer(lx, image);
 
-		analyzer.run(lx);
-		print_code(lx, image, analyzer);
-	} catch (const std::exception &e) {
-		std::cerr << std::dec << e.what() << std::endl;
-	}
+        analyzer.run(lx);
+        print_code(lx, image, analyzer);
+    } catch (const std::exception &e) {
+        std::cerr << std::dec << e.what() << std::endl;
+    }
 }

--- a/print.h
+++ b/print.h
@@ -1,261 +1,258 @@
-#ifndef SRC_PRINT_H_
-#define SRC_PRINT_H_
+#ifndef LE_DISASM_PRINT_H_
+#define LE_DISASM_PRINT_H_
 
 #include "analyzer.h"
 #include "le/image.h"
 #include "print_data.h"
 
 static std::string replace_addresses_with_labels(Insn &inst, Image &img, LinearExecutable &lx, Analyzer &anal) {
-	std::ostringstream oss;
-	size_t n, start;
-	uint32_t addr;
-	std::string addr_str;
-	std::string comment;
-	char prefix_symbol;
-	const std::string &str = inst.text;
+    std::ostringstream oss;
+    size_t n, start;
+    uint32_t addr;
+    std::string addr_str;
+    std::string comment;
+    char prefix_symbol;
+    const std::string &str = inst.text;
 
-	/* Many opcodes support displacement in indirect addressing modes.
-	 * Example: mov    %edx,-0x10(%ebp) .
-	 * Displacement constants are signed literals and should not be misinterpreted
-	 * as unsigned fixup addresses.
-	 */
+    /* Many opcodes support displacement in indirect addressing modes.
+     * Example: mov    %edx,-0x10(%ebp) .
+     * Displacement constants are signed literals and should not be misinterpreted
+     * as unsigned fixup addresses.
+     */
 
-	n = str.find ("0x");
-	  if (n == std::string::npos)
-	    return str;
+    n = str.find("0x");
+    if (n == std::string::npos) return str;
 
-	start = 0;
+    start = 0;
 
-	do {
-		prefix_symbol = *str.substr(n - sizeof(char), sizeof(char)).c_str();
-		oss << str.substr(start, n - start);
+    do {
+        prefix_symbol = *str.substr(n - sizeof(char), sizeof(char)).c_str();
+        oss << str.substr(start, n - start);
 
-		if (n + 2 >= str.length())
-			break;
+        if (n + 2 >= str.length()) break;
 
-		n += 2;
-		start = n;
+        n += 2;
+        start = n;
 
-		while (n < str.length() and isxdigit(str[n]))
-			n++;
+        while (n < str.length() and isxdigit(str[n])) n++;
 
-		addr_str = str.substr(start, n - start);
-		addr = strtol(addr_str.c_str(), NULL, 16);
-		if (inst.addressMode == Insn::mode_16bit and inst.memoryAddress == addr
-				and inst.type == Insn::MISC) {
-			const ImageObject &obj = img.objectAt(inst.instructionAddress);
-			/* assume that ds and cs equal segment base in 16 bit mode */
-			uint32_t virtual_address = obj.base_address + inst.memoryAddress;
-			Region *reg = anal.regions.regionContaining(virtual_address);
-			if (reg and reg->type == DATA) {
-				//addr = virtual_address; GCC throws "relocation truncated to fit: R_386_16 against .data" error.
-			}
-		}
-		std::map<uint32_t, Type>::const_iterator lab = anal.regions.labelTypes.find(addr);
-		if (prefix_symbol != '-' /* && prefix_symbol != '$' */
-				&& anal.regions.labelTypes.end() != lab) {
-			printTypedAddress(oss, addr, lab->second);
-		} else {
-			printAddress(oss, addr);
+        addr_str = str.substr(start, n - start);
+        addr = strtol(addr_str.c_str(), NULL, 16);
+        if (inst.bitness() == BITNESS_16BIT and inst.memoryAddress == addr and inst.type == Insn::MISC) {
+            /* assume that ds and cs equal segment base in 16 bit mode */
+            uint32_t virtual_address = inst.base_address() + inst.memoryAddress;
+            Region *reg = anal.regions.regionContaining(virtual_address);
+            if (reg and reg->type() == DATA) {
+                // addr = virtual_address; GCC throws "relocation truncated to fit: R_386_16 against .data" error.
+            }
+        }
+        std::map<uint32_t, Type>::const_iterator lab = anal.regions.labelTypes.find(addr);
+        if (prefix_symbol != '-' /* && prefix_symbol != '$' */
+            && anal.regions.labelTypes.end() != lab) {
+            printTypedAddress(oss, addr, lab->second);
+        } else {
+            printAddress(oss, addr);
 
-			if (lx.fixup_addresses.find(addr) != lx.fixup_addresses.end()) {
-				img.objectAt(addr);	// throws
-				comment = " /* Warning: address points to a valid object/reloc, but no label found */";
-			}
-		}
+            if (lx.fixup_addresses.find(addr) != lx.fixup_addresses.end()) {
+                img.objectAt(addr);  // throws
+                comment = " /* Warning: address points to a valid object/reloc, but no label found */";
+            }
+        }
 
-		start = n;
-		n = str.find("0x", start);
-	} while (n != std::string::npos);
+        start = n;
+        n = str.find("0x", start);
+    } while (n != std::string::npos);
 
-	if (start < str.length()) {
-		oss << str.substr(start);
-	}
-	if (!comment.empty()) {
-		oss << comment;
-	}
-	return oss.str();
+    if (start < str.length()) {
+        oss << str.substr(start);
+    }
+    if (!comment.empty()) {
+        oss << comment;
+    }
+    return oss.str();
 }
 
 static void print_instruction(Insn &inst, Image &img, LinearExecutable &lx, Analyzer &anal) {
-	std::string str;
-	std::string::size_type n;
+    std::string str;
+    std::string::size_type n;
 
-	str = replace_addresses_with_labels(inst, img, lx, anal);
+    str = replace_addresses_with_labels(inst, img, lx, anal);
 
-	n = str.find("(287 only)");
-	if (n != std::string::npos) {
-		std::cout << "\t\t/* " << str << " -- ignored */\n";
-		return;
-	}
+    n = str.find("(287 only)");
+    if (n != std::string::npos) {
+        std::cout << "\t\t/* " << str << " -- ignored */\n";
+        return;
+    }
 
-	/* Work around buggy libopcodes */
-	if (str == "lar    %cx,%ecx") {
-		str = "lar    %ecx,%ecx";
-	} else if (str == "lsl    %ax,%eax") {
-		str = "lsl    %eax,%eax";
-	} else if (str == "lea    0x000000(%eax,%eiz,1),%eax") {
-		str = "lea    0x000000(%eax),%eax";
-	} else if (str == "lea    0x000000(%edx,%eiz,1),%edx") {
-		str = "lea    0x000000(%edx),%edx";	// https://www.technovelty.org/arch/the-quickest-way-to-do-nothing.html
-	}
-	std::cout << "\t\t" << str;
+    /* Work around buggy libopcodes */
+    if (str == "lar    %cx,%ecx") {
+        str = "lar    %ecx,%ecx";
+    } else if (str == "lsl    %ax,%eax") {
+        str = "lsl    %eax,%eax";
+    } else if (str == "lea    0x000000(%eax,%eiz,1),%eax") {
+        str = "lea    0x000000(%eax),%eax";
+    } else if (str == "lea    0x000000(%edx,%eiz,1),%edx") {
+        str = "lea    0x000000(%edx),%edx";  // https://www.technovelty.org/arch/the-quickest-way-to-do-nothing.html
+    }
+    std::cout << "\t\t" << str;
 
-	if (str == "data16" or str == "data32") {
-		std::cout << " ";
-	} else {
-		std::cout << "\n";
-	}
+    if (str == "data16" or str == "data32") {
+        std::cout << " ";
+    } else {
+        std::cout << "\n";
+    }
 }
 
-static void printCodeTypeRegion(const Region &reg, const ImageObject &obj, LinearExecutable &lx, Image &img, Analyzer &anal) {
-	DisInfo disasm(obj.bitness == ImageObject::DEFAULT_BITNESS_32BIT ? bfd_mach_i386_i386 : bfd_mach_i386_i8086);
-	Insn inst;
+static void printCodeTypeRegion(const Region &reg, const ImageObject &obj, LinearExecutable &lx, Image &img,
+                                Analyzer &anal) {
+    DisInfo disasm;
+    Insn inst(std::addressof(obj));
 
-	for (uint32_t addr = reg.get_address(); addr < reg.get_end_address();) {
-		std::map<uint32_t, Type>::iterator type = anal.regions.labelTypes.find(addr);
-		if (anal.regions.labelTypes.end() != type) {
-//			if (CASE == type->second) {	// newline makes case not be part of function
-				std::cout << std::endl;
-//			}
-			printLabel(addr, type->second) << std::endl;
-		}
+    for (uint32_t addr = reg.address(); addr < reg.end_address();) {
+        std::map<uint32_t, Type>::iterator type = anal.regions.labelTypes.find(addr);
+        if (anal.regions.labelTypes.end() != type) {
+            //			if (CASE == type->second) {	// newline makes case not be part of function
+            std::cout << std::endl;
+            //			}
+            printLabel(addr, type->second) << std::endl;
+        }
 
-		disasm.disassemble(addr, obj.get_data_at(addr), reg.get_end_address() - addr, inst);
-		if (anal.regions.labelTypes.end() == type && inst.size > 1) {	// hack for corrupted libraries
-			type = anal.regions.labelTypes.find(addr + inst.size / 2);
-			if (anal.regions.labelTypes.end() != type) {
-				printLabel(addr + inst.size / 2, type->second) << "\t/* WARNING: instructions around this label are incorrect, generated just to workaround corrupted library */" << std::endl;
-			}
-		}
-		print_instruction(inst, img, lx, anal);
-		addr += inst.size;
-	}
+        disasm.disassemble(addr, obj.get_data_at(addr), reg.end_address() - addr, inst);
+        if (anal.regions.labelTypes.end() == type && inst.size > 1) {  // hack for corrupted libraries
+            type = anal.regions.labelTypes.find(addr + inst.size / 2);
+            if (anal.regions.labelTypes.end() != type) {
+                printLabel(addr + inst.size / 2, type->second)
+                    << "\t/* WARNING: instructions around this label are incorrect, generated just to workaround "
+                       "corrupted library */"
+                    << std::endl;
+            }
+        }
+        print_instruction(inst, img, lx, anal);
+        addr += inst.size;
+    }
 }
 
+static void printSwitchTypeRegion(const Region &reg, const ImageObject &obj, LinearExecutable &lx, Image &img,
+                                  Analyzer &anal) {
+    uint32_t func_addr, addr = reg.address();
 
-static void printSwitchTypeRegion(const Region &reg, const ImageObject &obj, LinearExecutable &lx, Image &img, Analyzer &anal) {
-	uint32_t func_addr, addr = reg.get_address();
+    /* TODO: limit by relocs */
+    printLabel(addr, anal.regions.labelTypes[addr]) << std::endl;
+    std::map<uint32_t, Type>::iterator next_label = anal.regions.labelTypes.upper_bound(addr);
 
-	/* TODO: limit by relocs */
-	printLabel(addr, anal.regions.labelTypes[addr]) << std::endl;
-	std::map<uint32_t, Type>::iterator next_label = anal.regions.labelTypes.upper_bound(addr);
+    while (addr < reg.end_address()) {
+        if (anal.regions.labelTypes.end() != next_label and addr == next_label->first) {
+            printLabel(addr, next_label->second) << std::endl;
+            next_label = anal.regions.labelTypes.upper_bound(addr);
+        }
 
-	while (addr < reg.get_end_address()) {
-		if (anal.regions.labelTypes.end() != next_label and addr == next_label->first) {
-			printLabel(addr, next_label->second) << std::endl;
-			next_label = anal.regions.labelTypes.upper_bound(addr);
-		}
+        func_addr = read_le<uint32_t>(obj.get_data_at(addr));
 
-		func_addr = read_le<uint32_t>(obj.get_data_at(addr));
-
-		if (func_addr != 0) {
-			if (addr < func_addr) {
-				anal.regions.labelTypes[func_addr] = CASE;
-			}
-			printTypedAddress(std::cout << "\t\t.long   ", func_addr, anal.regions.labelTypes[func_addr]) << std::endl;
-		} else {
-			std::cout << "\t\t.long   0\n";
-		}
-		addr += sizeof(uint32_t);
-	}
-	std::cout << std::endl;
+        if (func_addr != 0) {
+            if (addr < func_addr) {
+                anal.regions.labelTypes[func_addr] = CASE;
+            }
+            printTypedAddress(std::cout << "\t\t.long   ", func_addr, anal.regions.labelTypes[func_addr]) << std::endl;
+        } else {
+            std::cout << "\t\t.long   0\n";
+        }
+        addr += sizeof(uint32_t);
+    }
+    std::cout << std::endl;
 }
 
 static void print_region(const Region &reg, const ImageObject &obj, LinearExecutable &lx, Image &img, Analyzer &anal) {
-	void (*printMethods[])(const Region &, const ImageObject &, LinearExecutable &, Image &, Analyzer &) = {NULL, printCodeTypeRegion, printDataTypeRegion, printSwitchTypeRegion};
-	if (UNKNOWN < reg.get_type() && reg.get_type() < sizeof(printMethods)/sizeof(printMethods[0])) {
-		(*printMethods[reg.get_type()])(reg, obj, lx, img, anal);
-	}
-	else {
-		/* Emit unidentified region data for reference. Hex editors like wxHexEditor
-		 * could be used to find and disassemble the rendered raw data that could
-		 * help further improve le_disasm analyzer and actual reengineering projects.
-		 */
-		std::cout << "\n\t\t/* Skipped " << std::dec << reg.size << " bytes of "
-				<< (obj.executable ? "executable " : "") << reg.type
-				<< " type data at virtual address 0x" << std::setfill('0')
-				<< std::setw(8) << std::hex << std::noshowbase
-				<< (uint32_t) reg.address << ":";
-		const uint8_t * data_pointer = obj.get_data_at(reg.address);
-		for (uint8_t index = 0; index < reg.size && data_pointer; ++index) {
-			if (index >= 16) {
-				std::cout << "\n\t\t * ...";
-				break;
-			}
-			if (index % 8 == 0) {
-				std::cout << "\n\t\t *\t";
-			}
-			std::cout << std::setfill('0') << std::setw(2) << std::hex
-					<< std::noshowbase << (uint32_t) data_pointer[index];
-		}
-		std::cout << "\n\t\t */" << std::endl;
-	}
+    void (*printMethods[])(const Region &, const ImageObject &, LinearExecutable &, Image &, Analyzer &) = {
+        NULL, printCodeTypeRegion, printDataTypeRegion, printSwitchTypeRegion};
+    if (UNKNOWN < reg.type() && reg.type() < sizeof(printMethods) / sizeof(printMethods[0])) {
+        (*printMethods[reg.type()])(reg, obj, lx, img, anal);
+    } else {
+        /* Emit unidentified region data for reference. Hex editors like wxHexEditor
+         * could be used to find and disassemble the rendered raw data that could
+         * help further improve le_disasm analyzer and actual reengineering projects.
+         */
+        std::cout << "\n\t\t/* Skipped " << std::dec << reg.size() << " bytes of "
+                  << (obj.is_executable() ? "executable " : "") << reg.type() << " type data at virtual address 0x"
+                  << std::setfill('0') << std::setw(8) << std::hex << std::noshowbase << (uint32_t)reg.address() << ":";
+        const uint8_t *data_pointer = obj.get_data_at(reg.address());
+        for (uint8_t index = 0; index < reg.size() && data_pointer; ++index) {
+            if (index >= 16) {
+                std::cout << "\n\t\t * ...";
+                break;
+            }
+            if (index % 8 == 0) {
+                std::cout << "\n\t\t *\t";
+            }
+            std::cout << std::setfill('0') << std::setw(2) << std::hex << std::noshowbase
+                      << (uint32_t)data_pointer[index];
+        }
+        std::cout << "\n\t\t */" << std::endl;
+    }
 }
 
-static void printChangedSectionType(const Region &reg, const Region * const reg_prev, Type &section) {
-	char sections[][6] = { "bug", ".text", ".data" };
+static void printChangedSectionType(const Region &reg, const Region *const reg_prev, Type &section) {
+    char sections[][6] = {"bug", ".text", ".data"};
 
-	if (reg_prev
-			and reg_prev->get_default_bitness() != reg.get_default_bitness()) {
-		if (reg.get_default_bitness() == Region::DEFAULT_BITNESS_32BIT) {
-			std::cout << std::endl << ".code32" << std::endl;
-		} else {
-			std::cout << std::endl << ".code16" << std::endl;
-		}
-	}
+    if (reg_prev and reg_prev->bitness() != reg.bitness()) {
+        if (reg.bitness() == BITNESS_32BIT) {
+            std::cout << std::endl << ".code32" << std::endl;
+        } else {
+            std::cout << std::endl << ".code16" << std::endl;
+        }
+    }
 
-	if (reg.get_type() == DATA) {
-		if (section != DATA) {
-			std::cout << std::endl << sections[section = DATA] << std::endl;
-		}
-	} else {
-		if (section != CODE) {
-			std::cout << std::endl << sections[section = CODE] << std::endl;
-		}
-	}
+    if (reg.type() == DATA) {
+        if (section != DATA) {
+            std::cout << std::endl << sections[section = DATA] << std::endl;
+        }
+    } else {
+        if (section != CODE) {
+            std::cout << std::endl << sections[section = CODE] << std::endl;
+        }
+    }
 }
 
 void print_code(LinearExecutable &lx, Image &img, Analyzer &anal) {
-	const Region *prev = NULL;
-	const Region *next;
-	Type section = CODE;
+    const Region *prev = NULL;
+    const Region *next;
+    Type section = CODE;
 
-	Regions &regions = anal.regions;
+    Regions &regions = anal.regions;
 
-	std::cerr << "Region count: " << regions.regions.size() << std::endl;
+    std::cerr << "Region count: " << regions.regions.size() << std::endl;
 
-	const ImageObject &obj = img.objectAt(lx.entryPointAddress());
-	if(obj.bitness == ImageObject::DEFAULT_BITNESS_32BIT){
-		std::cout << ".code32" << std::endl;
-	} else {
-		std::cout << ".code16" << std::endl;
-	}
-	std::cout << ".text" << std::endl;
-	std::cout << ".globl _start" << std::endl;
-	std::cout << "_start:" << std::endl;
-	printTypedAddress(std::cout << "\t\tjmp\t", lx.entryPointAddress(), FUNCTION) << std::endl;
+    const ImageObject &obj = img.objectAt(lx.entryPointAddress());
+    if (obj.bitness() == BITNESS_32BIT) {
+        std::cout << ".code32" << std::endl;
+    } else {
+        std::cout << ".code16" << std::endl;
+    }
+    std::cout << ".text" << std::endl;
+    std::cout << ".globl _start" << std::endl;
+    std::cout << "_start:" << std::endl;
+    printTypedAddress(std::cout << "\t\tjmp\t", lx.entryPointAddress(), FUNCTION) << std::endl;
 
-	for (std::map<uint32_t, Region>::const_iterator itr = regions.regions.begin(); itr != regions.regions.end(); ++itr) {
-		const Region &reg = itr->second;
-		const ImageObject &obj = img.objectAt(reg.get_address());
+    for (std::map<uint32_t, Region>::const_iterator itr = regions.regions.begin(); itr != regions.regions.end();
+         ++itr) {
+        const Region &reg = itr->second;
+        const ImageObject &obj = img.objectAt(reg.address());
 
-		printChangedSectionType(reg, prev, section);
+        printChangedSectionType(reg, prev, section);
 
-		print_region(reg, obj, lx, img, anal);
+        print_region(reg, obj, lx, img, anal);
 
-		assert(prev == NULL || prev->get_end_address() <= reg.get_address());
+        assert(prev == NULL || prev->end_address() <= reg.address());
 
-		next = regions.nextRegion(reg);
-		if (next == NULL or next->get_address() > reg.get_end_address()) {
-			std::map<uint32_t, Type>::iterator type = anal.regions.labelTypes.find(reg.get_end_address());
-			if (anal.regions.labelTypes.end() != type) {
-				printLabel(reg.get_end_address(), type->second) << std::endl;
-			}
-		}
+        next = regions.nextRegion(reg);
+        if (next == NULL or next->address() > reg.end_address()) {
+            std::map<uint32_t, Type>::iterator type = anal.regions.labelTypes.find(reg.end_address());
+            if (anal.regions.labelTypes.end() != type) {
+                printLabel(reg.end_address(), type->second) << std::endl;
+            }
+        }
 
-		prev = &reg;
-	}
+        prev = &reg;
+    }
 }
 
-#endif /* SRC_PRINT_H_ */
+#endif /* LE_DISASM_PRINT_H_ */

--- a/print.h
+++ b/print.h
@@ -98,8 +98,9 @@ static void print_instruction(Insn &inst, Image &img, LinearExecutable &lx, Anal
 }
 
 static void printCodeTypeRegion(const Region &reg, const ImageObject &obj, LinearExecutable &lx, Image &img, Analyzer &anal) {
-	DisInfo disasm;
+	DisInfo disasm(obj.bitness == ImageObject::DEFAULT_BITNESS_32BIT ? bfd_mach_i386_i386 : bfd_mach_i386_i8086);
 	Insn inst;
+
 	for (uint32_t addr = reg.get_address(); addr < reg.get_end_address();) {
 		std::map<uint32_t, Type>::iterator type = anal.regions.labelTypes.find(addr);
 		if (anal.regions.labelTypes.end() != type) {

--- a/print_data.h
+++ b/print_data.h
@@ -1,207 +1,212 @@
-#ifndef PRINT_DATA_H_
-#define PRINT_DATA_H_
+#ifndef LE_DISASM_PRINT_DATA_H_
+#define LE_DISASM_PRINT_DATA_H_
 
 static int getIndent(Type type) {
-	if (JUMP == type || CASE == type) {
-		return 1;
-	} else if (FUNCTION == type || FUNC_GUESS == type) {
-		std::cout << "\n\n";
-//		print_separator();
-	} else if (SWITCH == type) {
-		std::cout << '\n';
-	}
-	return 0;
+    if (JUMP == type || CASE == type) {
+        return 1;
+    } else if (FUNCTION == type || FUNC_GUESS == type) {
+        std::cout << "\n\n";
+        //		print_separator();
+    } else if (SWITCH == type) {
+        std::cout << '\n';
+    }
+    return 0;
 }
 
 static std::ostream &printTypedAddress(std::ostream &os, uint32_t address, Type type) {
-	switch (type) {
-	case FUNCTION:
-		return printAddress(os, address, "_") << "_func";
-	case FUNC_GUESS:
-		return printAddress(os, address, "_") << "_func";//"_funcGuess";
-	case JUMP:
-		return printAddress(os, address, "_") << "_jump";
-	case DATA:
-		return printAddress(os, address, "_") << "_data";
-	case SWITCH:
-		return printAddress(os, address, "_") << "_switch";
-	case CASE:
-		return printAddress(os, address, "_") << "_case";
-	default:
-		return printAddress(os, address, "_") << "_unknown";
-	}
+    switch (type) {
+        case FUNCTION:
+            return printAddress(os, address, "_") << "_func";
+        case FUNC_GUESS:
+            return printAddress(os, address, "_") << "_func";  //"_funcGuess";
+        case JUMP:
+            return printAddress(os, address, "_") << "_jump";
+        case DATA:
+            return printAddress(os, address, "_") << "_data";
+        case SWITCH:
+            return printAddress(os, address, "_") << "_switch";
+        case CASE:
+            return printAddress(os, address, "_") << "_case";
+        default:
+            return printAddress(os, address, "_") << "_unknown";
+    }
 }
 
-std::ostream & printLabel(uint32_t address, Type type, char const *prefix = "") {
-	for (int indent = getIndent(type); indent-- > 0; std::cout << '\t');
-	printTypedAddress(std::cout << prefix, address, type) << ":";
-//	TODO: if (!lab->get_name().empty()) {
-//		std::cout << "\t/* " << lab->get_address() << " */";
-//	}
-	return std::cout;
+std::ostream &printLabel(uint32_t address, Type type, char const *prefix = "") {
+    for (int indent = getIndent(type); indent-- > 0; std::cout << '\t')
+        ;
+    printTypedAddress(std::cout << prefix, address, type) << ":";
+    //	TODO: if (!lab->get_name().empty()) {
+    //		std::cout << "\t/* " << lab->get_address() << " */";
+    //	}
+    return std::cout;
 }
 
 static bool data_is_address(const ImageObject &obj, uint32_t addr, size_t len, LinearExecutable &lx) {
-	if (len >= 4) {
-		const std::map<uint32_t, uint32_t> &fups = lx.fixups[obj.index];
-		return fups.find(addr - obj.base_address) != fups.end();
-	}
-	return false;
+    if (len >= 4) {
+        const std::map<uint32_t, uint32_t> &fups = lx.fixups[obj.index()];
+        return fups.find(addr - obj.base_address()) != fups.end();
+    }
+    return false;
 }
 
 static bool data_is_zeros(const ImageObject &obj, uint32_t addr, size_t len, size_t &rlen) {
-	size_t x;
-	const uint8_t *data = obj.get_data_at(addr);
+    size_t x;
+    const uint8_t *data = obj.get_data_at(addr);
 
-	for (x = 0; x < len; x++) {
-		if (data[x] != 0) {
-			break;
-		}
-	}
+    for (x = 0; x < len; x++) {
+        if (data[x] != 0) {
+            break;
+        }
+    }
 
-	if (x < 4) {
-		return false;
-	}
-	rlen = x;
-	return true;
+    if (x < 4) {
+        return false;
+    }
+    rlen = x;
+    return true;
 }
 
 static bool data_is_string(const ImageObject &obj, uint32_t addr, size_t len, size_t &rlen, bool &zero_terminated) {
-	size_t x;
-	const uint8_t *data = obj.get_data_at(addr);
+    size_t x;
+    const uint8_t *data = obj.get_data_at(addr);
 
-	for (x = 0; x < len; x++) {
-		if ((data[x] < 0x20 or data[x] >= 0x7f) and not (data[x] == '\t' or data[x] == '\n' or data[x] == '\r')) {
-			break;
-		}
-	}
+    for (x = 0; x < len; x++) {
+        if ((data[x] < 0x20 or data[x] >= 0x7f) and not(data[x] == '\t' or data[x] == '\n' or data[x] == '\r')) {
+            break;
+        }
+    }
 
-	if (x < 4) {
-		return false;
-	}
+    if (x < 4) {
+        return false;
+    }
 
-	if (x < len and data[x] == 0) {
-		zero_terminated = true;
-		x += 1;
-	} else {
-		zero_terminated = false;
-	}
-	rlen = x;
-	return true;
+    if (x < len and data[x] == 0) {
+        zero_terminated = true;
+        x += 1;
+    } else {
+        zero_terminated = false;
+    }
+    rlen = x;
+    return true;
 }
 
 static void print_escaped_string(const uint8_t *data, size_t len) {
-	size_t n;
+    size_t n;
 
-	for (n = 0; n < len; n++) {
-		if (data[n] == '\t')
-			std::cout << "\\t";
-		else if (data[n] == '\r')
-			std::cout << "\\r";
-		else if (data[n] == '\n')
-			std::cout << "\\n";
-		else if (data[n] == '\\')
-			std::cout << "\\\\";
-		else if (data[n] == '"')
-			std::cout << "\\\"";
-		else
-			std::cout << (char) data[n];
-	}
+    for (n = 0; n < len; n++) {
+        if (data[n] == '\t')
+            std::cout << "\\t";
+        else if (data[n] == '\r')
+            std::cout << "\\r";
+        else if (data[n] == '\n')
+            std::cout << "\\n";
+        else if (data[n] == '\\')
+            std::cout << "\\\\";
+        else if (data[n] == '"')
+            std::cout << "\\\"";
+        else
+            std::cout << (char)data[n];
+    }
 }
 
 void completeStringQuoting(int &bytes_in_line, int resetTo = 0) {
-	if (bytes_in_line > 0) {
-		std::cout << "\"\n";
-		bytes_in_line = resetTo;
-	}
+    if (bytes_in_line > 0) {
+        std::cout << "\"\n";
+        bytes_in_line = resetTo;
+    }
 }
 
-static size_t getLen(const Region &reg, const ImageObject &obj, Analyzer &anal, std::map<uint32_t/*offset*/, uint32_t/*address*/> &fups, std::map<uint32_t, uint32_t>::const_iterator &itr, uint32_t addr) {
-	size_t len = reg.get_end_address() - addr;
+static size_t getLen(const Region &reg, const ImageObject &obj, Analyzer &anal,
+                     std::map<uint32_t /*offset*/, uint32_t /*address*/> &fups,
+                     std::map<uint32_t, uint32_t>::const_iterator &itr, uint32_t addr) {
+    size_t len = reg.end_address() - addr;
 
-	std::map<uint32_t, Type>::iterator label = anal.regions.labelTypes.upper_bound(addr);
-	if (anal.regions.labelTypes.end() != label) {
-		len = std::min<size_t>(len, label->first - addr);
-	}
+    std::map<uint32_t, Type>::iterator label = anal.regions.labelTypes.upper_bound(addr);
+    if (anal.regions.labelTypes.end() != label) {
+        len = std::min<size_t>(len, label->first - addr);
+    }
 
-	while (fups.end() != itr and itr->first <= addr - obj.base_address) {
-		++itr;
-	}
+    while (fups.end() != itr and itr->first <= addr - obj.base_address()) {
+        ++itr;
+    }
 
-	if (itr != fups.end()) {
-		len = std::min<size_t>(len, itr->first - (addr - obj.base_address));
-	}
-	return len;
+    if (itr != fups.end()) {
+        len = std::min<size_t>(len, itr->first - (addr - obj.base_address()));
+    }
+    return len;
 }
 
-static void printDataAfterFixup(const ImageObject &obj, LinearExecutable &lx, Analyzer &anal, uint32_t &addr, size_t len, int &bytes_in_line) {
-	size_t size;
-	bool zt;
-	while (len > 0) {
-		if (data_is_address(obj, addr, len, lx)) {
-			completeStringQuoting(bytes_in_line);
-			uint32_t value = read_le<uint32_t>(obj.get_data_at(addr));
-			printTypedAddress(std::cout << "\t\t.long   ", value, anal.regions.labelTypes[value]) << std::endl;
+static void printDataAfterFixup(const ImageObject &obj, LinearExecutable &lx, Analyzer &anal, uint32_t &addr,
+                                size_t len, int &bytes_in_line) {
+    size_t size;
+    bool zt;
+    while (len > 0) {
+        if (data_is_address(obj, addr, len, lx)) {
+            completeStringQuoting(bytes_in_line);
+            uint32_t value = read_le<uint32_t>(obj.get_data_at(addr));
+            printTypedAddress(std::cout << "\t\t.long   ", value, anal.regions.labelTypes[value]) << std::endl;
 
-			addr += 4;
-			len -= 4;
-		} else if (data_is_zeros(obj, addr, len, size)) {
-			completeStringQuoting(bytes_in_line);
+            addr += 4;
+            len -= 4;
+        } else if (data_is_zeros(obj, addr, len, size)) {
+            completeStringQuoting(bytes_in_line);
 
-			std::cout << "\t\t.fill   0x" << std::hex << size << std::endl;
-			addr += size;
-			len -= size;
-		} else if (data_is_string(obj, addr, len, size, zt)) {
-			completeStringQuoting(bytes_in_line);
+            std::cout << "\t\t.fill   0x" << std::hex << size << std::endl;
+            addr += size;
+            len -= size;
+        } else if (data_is_string(obj, addr, len, size, zt)) {
+            completeStringQuoting(bytes_in_line);
 
-			if (zt) {
-				std::cout << "\t\t.string \"";
-			} else {
-				std::cout << "\t\t.ascii   \"";
-			}
-			print_escaped_string(obj.get_data_at(addr), size - zt);
+            if (zt) {
+                std::cout << "\t\t.string \"";
+            } else {
+                std::cout << "\t\t.ascii   \"";
+            }
+            print_escaped_string(obj.get_data_at(addr), size - zt);
 
-			std::cout << "\"\n";
+            std::cout << "\"\n";
 
-			addr += size;
-			len -= size;
-		} else {
-			char buffer[8];
+            addr += size;
+            len -= size;
+        } else {
+            char buffer[8];
 
-			if (bytes_in_line == 0)
-				std::cout << "\t\t.ascii  \"";
+            if (bytes_in_line == 0) std::cout << "\t\t.ascii  \"";
 
-			snprintf(buffer, sizeof(buffer), "\\x%02x", *obj.get_data_at(addr));
-			std::cout << buffer;
+            snprintf(buffer, sizeof(buffer), "\\x%02x", *obj.get_data_at(addr));
+            std::cout << buffer;
 
-			bytes_in_line += 1;
+            bytes_in_line += 1;
 
-			if (bytes_in_line == 8) {
-				std::cout << "\"\n";
-				bytes_in_line = 0;
-			}
+            if (bytes_in_line == 8) {
+                std::cout << "\"\n";
+                bytes_in_line = 0;
+            }
 
-			addr++;
-			len--;
-		}
-	}
+            addr++;
+            len--;
+        }
+    }
 }
 
 void printDataTypeRegion(const Region &reg, const ImageObject &obj, LinearExecutable &lx, Image &img, Analyzer &anal) {
-	int bytes_in_line = 0;
-	uint32_t addr = reg.get_address();
-	std::map<uint32_t/*offset*/, uint32_t/*address*/> &fups = lx.fixups[obj.index];
-	for (std::map<uint32_t, uint32_t>::const_iterator itr = fups.begin(); addr < reg.get_end_address();) {
-		std::map<uint32_t, Type>::iterator label = anal.regions.labelTypes.find(addr);
-		if (anal.regions.labelTypes.end() != label) {
-			completeStringQuoting(bytes_in_line);
-			std::cout << std::endl;
-			printLabel(addr, DATA) /*<< stringNameFromValue(FIXME: too late to do it here, printTypedAddress() needs to do the same) */<< std::endl;
-		}
-		size_t len = getLen(reg, obj, anal, fups, itr, addr);
-		printDataAfterFixup(obj, lx, anal, addr, len, bytes_in_line);
-	}
-	completeStringQuoting(bytes_in_line, bytes_in_line);
+    int bytes_in_line = 0;
+    uint32_t addr = reg.address();
+    std::map<uint32_t /*offset*/, uint32_t /*address*/> &fups = lx.fixups[obj.index()];
+    for (std::map<uint32_t, uint32_t>::const_iterator itr = fups.begin(); addr < reg.end_address();) {
+        std::map<uint32_t, Type>::iterator label = anal.regions.labelTypes.find(addr);
+        if (anal.regions.labelTypes.end() != label) {
+            completeStringQuoting(bytes_in_line);
+            std::cout << std::endl;
+
+            printLabel(addr, DATA) << std::endl; /*<< stringNameFromValue(FIXME: too late to do it here,
+                                                    printTypedAddress() needs to do the same) */
+        }
+        size_t len = getLen(reg, obj, anal, fups, itr, addr);
+        printDataAfterFixup(obj, lx, anal, addr, len, bytes_in_line);
+    }
+    completeStringQuoting(bytes_in_line, bytes_in_line);
 }
 
-#endif /* PRINT_DATA_H_ */
+#endif /* LE_DISASM_PRINT_DATA_H_ */

--- a/region.h
+++ b/region.h
@@ -4,16 +4,23 @@
 #include "type.h"
 
 struct Region {
-	Region(uint32_t address_, uint32_t size_, Type type_) {
+	enum DefaultBitness {
+		DEFAULT_BITNESS_32BIT,
+		DEFAULT_BITNESS_16BIT
+	};
+
+	Region(uint32_t address_, uint32_t size_, Type type_, DefaultBitness bitness_ = DEFAULT_BITNESS_32BIT) {
 		address = address_;
 		size = size_;
 		type = type_;
+		bitness = bitness_;
 	}
 
 	Region(void) {
 		this->address = 0;
 		this->size = 0;
 		this->type = UNKNOWN;
+		this->bitness = DEFAULT_BITNESS_32BIT;
 	}
 
 	Region(const Region &other) {
@@ -40,9 +47,14 @@ struct Region {
 		return this->size;
 	}
 
+	DefaultBitness get_default_bitness(void) const {
+		return this->bitness;
+	}
+
 	uint32_t address;
 	uint32_t size;
 	Type type;
+	DefaultBitness bitness;
 };
 
 std::ostream &operator<<(std::ostream &os, Type type) {

--- a/region.h
+++ b/region.h
@@ -1,80 +1,63 @@
-#ifndef SRC_REGION_H_
-#define SRC_REGION_H_
+#ifndef LE_DISASM_REGION_H_
+#define LE_DISASM_REGION_H_
 
-#include "type.h"
+#include "le/image_object.h"
 
-struct Region {
-	enum DefaultBitness {
-		DEFAULT_BITNESS_32BIT,
-		DEFAULT_BITNESS_16BIT
-	};
+class Region {
+    const ImageObject *image_object_pointer_;
+    uint32_t address_;
+    uint32_t size_;
+    Type type_;
 
-	Region(uint32_t address_, uint32_t size_, Type type_, DefaultBitness bitness_ = DEFAULT_BITNESS_32BIT) {
-		address = address_;
-		size = size_;
-		type = type_;
-		bitness = bitness_;
-	}
+public:
+    Region(uint32_t address, uint32_t size, Type type, const ImageObject *image_object_pointer = NULL) {
+        address_ = address;
+        size_ = size;
+        type_ = type;
+        image_object_pointer_ = image_object_pointer;
+    }
 
-	Region(void) {
-		this->address = 0;
-		this->size = 0;
-		this->type = UNKNOWN;
-		this->bitness = DEFAULT_BITNESS_32BIT;
-	}
+    Region(void) {
+        address_ = 0;
+        size_ = 0;
+        type_ = UNKNOWN;
+        image_object_pointer_ = NULL;
+    }
 
-	Region(const Region &other) {
-		*this = other;
-	}
-
-	uint32_t get_address(void) const {
-		return this->address;
-	}
-
-	size_t get_end_address(void) const {
-		return (this->address + this->size);
-	}
-
-	Type get_type(void) const {
-		return this->type;
-	}
-
-	bool contains_address(uint32_t addr) const {
-		return (this->address <= addr and addr < this->address + this->size);
-	}
-
-	size_t get_size(void) const {
-		return this->size;
-	}
-
-	DefaultBitness get_default_bitness(void) const {
-		return this->bitness;
-	}
-
-	uint32_t address;
-	uint32_t size;
-	Type type;
-	DefaultBitness bitness;
+    Region(const Region &other) { *this = other; }
+    uint32_t address() const { return address_; }
+    size_t end_address() const { return (address_ + size_); }
+    Type type() const { return type_; }
+    bool contains_address(uint32_t address) const { return (address_ <= address and address < address_ + size_); }
+    size_t size() const { return size_; }
+    void size(size_t size) { size_ = size; }
+    Bitness bitness() const {
+        assert(image_object_pointer_);
+        return image_object_pointer_->bitness();
+    }
+    const ImageObject *image_object_pointer() { return image_object_pointer_; }
+    void image_object_pointer(const ImageObject *image_object_pointer) { image_object_pointer_ = image_object_pointer; }
 };
 
 std::ostream &operator<<(std::ostream &os, Type type) {
-	switch (type) {
-	case UNKNOWN:
-		return os << "unknown";
-	case CODE:
-		return os << "code";
-	case DATA:
-		return os << "data";
-	case SWITCH:
-		return os << "switch";
-	default:
-		return os << "(unknown " << type << ")";
-	}
+    switch (type) {
+        case UNKNOWN:
+            return os << "unknown";
+        case CODE:
+            return os << "code";
+        case DATA:
+            return os << "data";
+        case SWITCH:
+            return os << "switch";
+        default:
+            return os << "(unknown " << type << ")";
+    }
 }
 
-std::ostream &operator<<(std::ostream &os, const Region &reg) {	// %7s @ 0x%06x[%6d]
-	FlagsRestorer _(os);
-	return printAddress(os << std::setw(7) << reg.get_type(), reg.get_address(), " @ 0x") << "[" << std::setw(6) << std::setfill(' ') << std::dec << reg.get_size() << "]";
+std::ostream &operator<<(std::ostream &os, const Region &reg) { /* %7s @ 0x%06x[%6d] */
+    FlagsRestorer _(os);
+    return printAddress(os << std::setw(7) << reg.type(), reg.address(), " @ 0x")
+           << "[" << std::setw(6) << std::setfill(' ') << std::dec << reg.size() << "]";
 }
 
-#endif /* SRC_REGION_H_ */
+#endif /* LE_DISASM_REGION_H_ */

--- a/regions.h
+++ b/regions.h
@@ -45,7 +45,7 @@ struct Regions {
 		assert(parent.contains_address(reg.get_end_address() - 1));
 
 		FlagsRestorer _(std::cerr);
-		Region next(reg.get_end_address(), parent.get_end_address() - reg.get_end_address(), parent.get_type());
+		Region next(reg.get_end_address(), parent.get_end_address() - reg.get_end_address(), parent.get_type(), parent.get_default_bitness());
 		std::cerr << parent << " split to ";
 
 		if (reg.get_address() != parent.get_address()) {
@@ -86,7 +86,10 @@ private:
 	}
 
 	Region *attemptMerge(Region *prev, Region *next) {
-		if (prev != NULL and next != NULL && prev->get_type() == next->get_type() and prev->get_end_address() == next->get_address()) {
+		if (prev != NULL and next != NULL
+				and prev->get_type() == next->get_type()
+				and prev->get_end_address() == next->get_address()
+				and prev->get_default_bitness() == next->get_default_bitness()) {
 			std::cerr << "Combining " << *prev << " and " << *next << std::endl;
 			prev->size += next->size;
 			regions.erase(next->get_address());

--- a/regions.h
+++ b/regions.h
@@ -1,102 +1,104 @@
-#ifndef SRC_REGIONS_H_
-#define SRC_REGIONS_H_
+#ifndef LE_DISASM_REGIONS_H_
+#define LE_DISASM_REGIONS_H_
 
-#include "le/object_header.h"
+#include "le/image.h"
 #include "region.h"
 
 struct Regions {
-	std::map<uint32_t, Region> regions;
-	std::map<uint32_t, Type> labelTypes;
+    std::map<uint32_t, Region> regions;
+    std::map<uint32_t, Type> labelTypes;
 
-	Regions(std::vector<ObjectHeader> &objects) {
-		for (size_t n = 0; n < objects.size(); ++n) {
-			ObjectHeader &ohdr = objects[n];
-			Type type = ohdr.isExecutable() ? UNKNOWN : DATA;
-			printAddress(std::cerr, ohdr.base_address, "Creating Region(0x") << ", " << std::dec << ohdr.virtual_size << ", " << type << ")" << std::endl;
-			regions[ohdr.base_address] = Region(ohdr.base_address,
-					ohdr.virtual_size, type,
-					ohdr.isDefaultObjectBitness32Bit() ?
-							Region::DEFAULT_BITNESS_32BIT :
-							Region::DEFAULT_BITNESS_16BIT);
-			if (!ohdr.isExecutable()) {
-				labelTypes[ohdr.base_address] = type;
-			}	// else no automatic label for lowest .text address
-		}
-	}
+    Regions(std::vector<ImageObject> &objects) {
+        for (size_t n = 0; n < objects.size(); ++n) {
+            ImageObject &obj = objects[n];
+            Type type = obj.is_executable() ? UNKNOWN : DATA;
+            printAddress(std::cerr, obj.base_address(), "Creating Region(0x") << ", " << std::dec << obj.size() << ", "
+                                                                              << type << ")" << std::endl;
+            regions[obj.base_address()] = Region(obj.base_address(), obj.size(), type, std::addressof(obj));
+            if (type == DATA) {
+                labelTypes[obj.base_address()] = type;
+            }  // else no automatic label for lowest .text address
+        }
+    }
 
-	Region *regionContaining(uint32_t address) {
-		std::map<uint32_t, Region>::iterator itr = regions.lower_bound(address);
-		if (regions.end() != itr) {
-			if (itr->first == address) {
-				return &itr->second;
-			} else if (regions.begin() == itr) {
-				return NULL;
-			}
-		}
-		if (regions.empty()) {
-			return NULL;
-		}
-		--itr;
-		return itr->second.contains_address(address) ? &itr->second : NULL;
-	}
+    Region *regionContaining(uint32_t address) {
+        std::map<uint32_t, Region>::iterator itr = regions.lower_bound(address);
+        if (regions.end() != itr) {
+            if (itr->first == address) {
+                return &itr->second;
+            } else if (regions.begin() == itr) {
+                return NULL;
+            }
+        }
+        if (regions.empty()) {
+            return NULL;
+        }
+        --itr;
+        return itr->second.contains_address(address) ? &itr->second : NULL;
+    }
 
-	void splitInsert(Region &parent, const Region &reg) {
-		assert(parent.contains_address(reg.get_address()));
-		assert(parent.contains_address(reg.get_end_address() - 1));
+    void splitInsert(Region &parent, const Region &target) {
+        assert(parent.contains_address(target.address()));
+        assert(parent.contains_address(target.end_address() - 1));
 
-		FlagsRestorer _(std::cerr);
-		Region next(reg.get_end_address(), parent.get_end_address() - reg.get_end_address(), parent.get_type(), parent.get_default_bitness());
-		std::cerr << parent << " split to ";
+        Region reg = target;
+        reg.image_object_pointer(parent.image_object_pointer());
+        FlagsRestorer _(std::cerr);
+        Region next(reg.end_address(), parent.end_address() - reg.end_address(), parent.type(),
+                    parent.image_object_pointer());
+        std::cerr << parent << " split to ";
 
-		if (reg.get_address() != parent.get_address()) {
-			parent.size = reg.get_address() - parent.get_address();
-			regions[reg.get_address()] = reg;
-			std::cerr << parent << ", " << reg;
-		} else {
-			parent = reg;
-			std::cerr << parent;
-		}
+        if (reg.address() != parent.address()) {
+            parent.size(reg.address() - parent.address());
+            regions[reg.address()] = reg;
+            std::cerr << parent << ", " << reg;
+        } else {
+            parent = reg;
+            std::cerr << parent;
+        }
 
-		if (next.size > 0) {
-			regions[reg.get_end_address()] = next;
-			std::cerr << ", " << next;
-		}
-		std::cerr << std::endl;
+        if (next.size() > 0) {
+            regions[reg.end_address()] = next;
+            std::cerr << ", " << next;
+        }
+        std::cerr << std::endl;
 
-		check_merge_regions(reg.get_address());
-	}
+        assert(reg.image_object_pointer());
+        assert(next.image_object_pointer());
+        assert(parent.image_object_pointer());
+        check_merge_regions(reg.address());
+    }
 
-	Region *nextRegion(const Region &reg) {
-		std::map<uint32_t, Region>::iterator itr = regions.upper_bound(reg.get_address());
-		return regions.end() != itr ? &itr->second : NULL;
-	}
+    Region *nextRegion(const Region &reg) {
+        std::map<uint32_t, Region>::iterator itr = regions.upper_bound(reg.address());
+        return regions.end() != itr ? &itr->second : NULL;
+    }
+
 private:
-	Region *previousRegion(const Region &reg) {
-		for (std::map<uint32_t, Region>::iterator itr = regions.lower_bound(reg.get_address()); regions.begin() != itr;) {
-			--itr;
-			return &itr->second;
-		}
-		return NULL;
-	}
+    Region *previousRegion(const Region &reg) {
+        for (std::map<uint32_t, Region>::iterator itr = regions.lower_bound(reg.address()); regions.begin() != itr;) {
+            --itr;
+            return &itr->second;
+        }
+        return NULL;
+    }
 
-	void check_merge_regions(uint32_t address) {
-		Region &reg = regions[address];
-		Region *merged = attemptMerge(previousRegion(reg), &reg);
-		attemptMerge(merged, nextRegion(*merged));
-	}
+    void check_merge_regions(uint32_t address) {
+        Region &reg = regions[address];
+        Region *merged = attemptMerge(previousRegion(reg), &reg);
+        attemptMerge(merged, nextRegion(*merged));
+    }
 
-	Region *attemptMerge(Region *prev, Region *next) {
-		if (prev != NULL and next != NULL
-				and prev->get_type() == next->get_type()
-				and prev->get_end_address() == next->get_address()
-				and prev->get_default_bitness() == next->get_default_bitness()) {
-			std::cerr << "Combining " << *prev << " and " << *next << std::endl;
-			prev->size += next->size;
-			regions.erase(next->get_address());
-			return prev;
-		}
-		return next;
-	}
+    Region *attemptMerge(Region *prev, Region *next) {
+        if (prev != NULL and next != NULL and prev->type() == next->type() and
+            prev->end_address() == next->address() and prev->bitness() == next->bitness()) {
+            std::cerr << "Combining " << *prev << " and " << *next << std::endl;
+            prev->size(prev->size() + next->size());
+            regions.erase(next->address());
+            return prev;
+        }
+        return next;
+    }
 };
 
-#endif /* SRC_REGIONS_H_ */
+#endif /* LE_DISASM_REGIONS_H_ */

--- a/regions.h
+++ b/regions.h
@@ -13,7 +13,11 @@ struct Regions {
 			ObjectHeader &ohdr = objects[n];
 			Type type = ohdr.isExecutable() ? UNKNOWN : DATA;
 			printAddress(std::cerr, ohdr.base_address, "Creating Region(0x") << ", " << std::dec << ohdr.virtual_size << ", " << type << ")" << std::endl;
-			regions[ohdr.base_address] = Region(ohdr.base_address, ohdr.virtual_size, type);
+			regions[ohdr.base_address] = Region(ohdr.base_address,
+					ohdr.virtual_size, type,
+					ohdr.isDefaultObjectBitness32Bit() ?
+							Region::DEFAULT_BITNESS_32BIT :
+							Region::DEFAULT_BITNESS_16BIT);
 			if (!ohdr.isExecutable()) {
 				labelTypes[ohdr.base_address] = type;
 			}	// else no automatic label for lowest .text address

--- a/type.h
+++ b/type.h
@@ -1,22 +1,24 @@
-#ifndef SRC_TYPE_H_
-#define SRC_TYPE_H_
+#ifndef LE_DISASM_TYPE_H_
+#define LE_DISASM_TYPE_H_
 
 #include "flags_restorer.h"
 
 std::ostream &printAddress(std::ostream &os, uint32_t address, const char *prefix = "0x") {
-	FlagsRestorer _(os);
-	return os << prefix << std::setfill('0') << std::setw(6) << std::hex << std::noshowbase << address;
+    FlagsRestorer _(os);
+    return os << prefix << std::setfill('0') << std::setw(6) << std::hex << std::noshowbase << address;
 }
 
 enum Type {
-	UNKNOWN,	// region
-	CODE, 		// region
-	DATA, 		// region, label
-	SWITCH, 	// region, label
-	JUMP, 		// label
-	FUNCTION,	// label
-	CASE,		// label
-	FUNC_GUESS	// label; either callback or data in code segment
+    UNKNOWN,   /* region */
+    CODE,      /* region */
+    DATA,      /* region, label */
+    SWITCH,    /* region, label */
+    JUMP,      /* label */
+    FUNCTION,  /* label */
+    CASE,      /* label */
+    FUNC_GUESS /* label; either callback or data in code segment */
 };
 
-#endif /* SRC_TYPE_H_ */
+enum Bitness { BITNESS_32BIT, BITNESS_16BIT };
+
+#endif /* LE_DISASM_TYPE_H_ */


### PR DESCRIPTION
The architecture was refactored in the following ways:
- class **Regions** add the initial segments as **Region** objects using the **ImageObject** class instead of the **ImageHeader** class. This way **Region** objects can hold a pointer to their parent **ImageObject** and could perform operations related to Image data internally which helps reduce complexity in upper layer classes like **Analyzer**.
- class **DisInfo** configures machine/architecture class required for disassembling from passed **Insn** objects. This way **DisInfo** objects do not need to provide interfaces to set/get bitness information.
- class **Insn** receives a pointer to its parent **ImageObject** object via constructor. The **ImageObject** pointer could come from parent **Region** or from externally looked up **ImageObjects**. It is important that **Insn** objects' life cycle is overlapped with **Region** split-up operations so the only truly safe parent could be the **ImageObject** which is basically read-only. As **Insn** objects could internally query bitness information from their parent **ImageObjects** and the same way **DisInfo** could query **Insn** objects for the same, upper layer callers could be oblivious about bitness information most of the times. Later on **Insn** objects could also introduce CS, DS, etc. register definitions to construct virtual addresses from linear or segmented offset addresses (the latter is important for 16 bit code segments) internally without exposing these details to upper layer callers.
- as some of the classes/structs were considerably changed (behavior or interface wise), it was a good opportunity to reformat the code base using a defined code formatter profile. I used clang-formatter; the related formatter configuration file is also added to the change set.

With this change set 16 bit code segments could be disassembled by the tool and data references pointing into the 16 bit code segment are also identified as far as DS is correctly assumed to be the same as the containing ImageObject.base_address(). The printer does not replace data references within 16 bit code, for now this feature is commented out on a single line as GCC cannot handle 16 bit data references (relocation truncated to fit: R_386_16 against .data" error), but data labels are emitted never the less.